### PR TITLE
Fix webdocs type infer links in constraints

### DIFF
--- a/src/Desugarf.hs
+++ b/src/Desugarf.hs
@@ -231,7 +231,7 @@ desClassDecl (className, classVars) subStatements = ([], (H.empty, H.singleton c
 
 desTypeDef :: PTypeDef -> [RawDeclSubStatement ParseMeta] -> DesObjectMap
 desTypeDef (TypeDef tp) subStatements = case typeDefMetaToObj H.empty tp of
-          Just Object{objM, objBasis, objName, objVars, objArgs, objDoc} -> [(Object objM objBasis objName objVars objArgs (desObjDocComment subStatements), [])]
+          Just obj -> [(obj{objDoc = desObjDocComment subStatements}, [])]
           Nothing  -> error "Type def could not be converted into meta"
 
 desClassDef :: Sealed -> RawClassDef -> [RawDeclSubStatement ParseMeta] -> DesPrgm
@@ -239,7 +239,7 @@ desClassDef sealed ((typeName, typeVars), className) subStatements = ([], classM
   where
     classMap = (
         H.singleton typeName (S.singleton className),
-        H.singleton className 
+        H.singleton className
         (sealed, H.empty, [singletonType (PartialType (PTypeName typeName) typeVars H.empty H.empty PtArgExact)], desObjDocComment subStatements)
       )
 

--- a/webdocs/src/ListProgram.js
+++ b/webdocs/src/ListProgram.js
@@ -10,7 +10,6 @@ import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import {Comment} from './DocsPage';
-import {useParams} from 'react-router-dom';
 import {
   useHistory,
   useLocation,
@@ -130,20 +129,30 @@ function ObjArrows(props) {
 }
 
 function Arrow(props) {
-  const {Meta} = props;
-  const [arrM, , guard, maybeExpr] = props.arrow;
+  const {Meta, showExprMetas} = props;
+  const [arrM, annots, guard, maybeExpr] = props.arrow;
   const classes = useStyles();
 
-  let showExpr;
-  if(maybeExpr) {
-    showExpr = <span> = <Expr expr={maybeExpr} Meta={Meta} showMetas={props.showExprMetas}/></span>;
+  let showAnnots;
+  if(annots.length > 0) {
+    showAnnots = annots.map((annot, index) => <div key={index}><Expr expr={annot} Meta={Meta} showMetas={showExprMetas}/></div>);
   }
 
-  let header = (<span><Guard guard={guard} Expr={Expr} Meta={Meta} showExprMetas={props.showExprMetas}/> -&gt; <Meta data={arrM} /></span>);
+  let arrRes;
+  if(arrM[0].tag !== "TopType") {
+    arrRes = <> -&gt; <Meta data={arrM} /></>;
+  }
+
+  let header = (<span><Guard guard={guard} Expr={Expr} Meta={Meta} showExprMetas={showExprMetas}/>{arrRes}</span>);
+  let showExpr;
+  if(maybeExpr) {
+    showExpr = <span> = <Expr expr={maybeExpr} Meta={Meta} showMetas={showExprMetas}/></span>;
+  }
 
   return (
     <Card className={classes.arrow}>
       <CardContent className={classes.arrowDeclaration}>{header}</CardContent>
+      {showAnnots ? showAnnots : ""}
       <CardContent className={classes.arrowExpression}>{showExpr}</CardContent>
     </Card>
   );
@@ -196,8 +205,8 @@ function Meta(props) {
 }
 
 export function ClassComments(props) {
-  const [_,classMap] = props.data;
-  const [typeToClass, classToType] = classMap;
+  const [,classMap] = props.data;
+  const [, classToType] = classMap;
   const { name } = props;
   let showComments = "";
   const classType = classToType[name] || [];

--- a/webdocs/src/TypeInfer.js
+++ b/webdocs/src/TypeInfer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext} from 'react';
 
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
@@ -20,20 +20,24 @@ const useStyles = makeStyles({
   }
 });
 
+const PrgmNameContext = React.createContext(undefined);
+
 function TypeInfer() {
   const { prgmName } = useParams();
   let apiResult = useApi(`/api/constrain?prgmName=${prgmName}`);
 
   return (
-    <Loading status={apiResult}>
-      <Main data={apiResult.data} notes={apiResult.notes} />
-    </Loading>
+    <PrgmNameContext.Provider value={prgmName}>
+      <Loading status={apiResult}>
+        <Main data={apiResult.data} notes={apiResult.notes} />
+      </Loading>
+    </PrgmNameContext.Provider>
   );
 }
 
 function Main(props) {
   let {notes, data: [, prgm, trace]} = props;
-  let { prgmName } = useParams();
+  let prgmName = useContext(PrgmNameContext);
   const classes = useStyles();
 
   var notesMap = {};
@@ -193,7 +197,7 @@ function Scheme(props) {
 
 function Pnt(props) {
   let {pnt} = props;
-  let { prgmName } = useParams();
+  let prgmName = useContext(PrgmNameContext);
   return <Link to={`/typeinfer/${prgmName}/${pnt}`}>{pnt}</Link>;
 }
 


### PR DESCRIPTION
The links relied on finding the prgmName from the params. However, the params
are changed as it is inside not the top-level route, but a second-level route.
So, this changes to passing the prgmName to the pnts through a context object
instead.