### PR TITLE
Use pedantic testing

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           enable-stack: true
           stack-version: 'latest'
-      - run: stack test
+      - run: stack test --pedantic

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build:
 	stack build --pedantic
 
+test:
+	stack test --pedantic
+
 format:
 	find app -name "*.hs" | xargs stylish-haskell -i
 	find src -name "*.hs" | xargs stylish-haskell -i

--- a/docs/contrib/building.md
+++ b/docs/contrib/building.md
@@ -1,6 +1,6 @@
 ## Building for development
 
-To build the compiler, you can run `stack build` from `$CATLN_HOME`.
+To build the compiler, you can run `stack build --pedantic` from `$CATLN_HOME`.
 
 Once it is built, you can execute the compiler on a Catln file by running `stack exec catln test/code/arith.ct`.
 


### PR DESCRIPTION
This updates the github CI to use the pedantic testing script. It also will stop
on anything which is a warning (like Werr) and can help maintain good code
quality as well as detect potential problems.