### PR TITLE
Types

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -132,7 +132,7 @@ metaTypeVar m = case getMetaType m of
 
 
 isSubtypePartialOfWithObj :: (Meta m) => ClassMap -> Object m -> PartialType -> Type -> Bool
-isSubtypePartialOfWithObj classMap Object{objVars, objArgs} = isSubtypePartialOfWithEnv classMap (fmap getMetaType objVars) (fmap (getMetaType . fst) objArgs)
+isSubtypePartialOfWithObj classMap Object{objVars, objArgs} sub = isSubtypeOfWithEnv classMap (fmap getMetaType objVars) (fmap (getMetaType . fst) objArgs) (singletonType sub)
 
 isSubtypeOfWithObj :: (Meta m) => ClassMap -> Object m -> Type -> Type -> Bool
 isSubtypeOfWithObj classMap obj@Object{objVars} = isSubtypeOfWithEnv classMap (fmap getMetaType objVars) (getMetaType <$> formArgMetaMap obj)

--- a/src/TypeCheck/Common.hs
+++ b/src/TypeCheck/Common.hs
@@ -268,8 +268,7 @@ verifyScheme classMap (VarMeta _ _ mobj) (TypeCheckResult _ (SType oldUb _ _)) (
     verifySchemeUbLowers (Just obj) = isSubtypeOfWithObj classMap obj ub oldUb
     verifySchemeUbLowers Nothing    = isSubtypeOf classMap ub oldUb
     verifyCompacted = ub == compactType classMap ub
-verifyScheme _ _ TypeCheckResE{} TypeCheckResult{} = Nothing
-verifyScheme _ _ _ _ = Just "fallthrough"
+verifyScheme _ _ _ _ = Nothing
 
 
 -- Point operations


### PR DESCRIPTION
This refactors many of the operations in syntax.types to make them simpler and
more reliable. It uses a standard splitPartials with consistent handling of
expandingClasses. However, it makes fewer assumptions which makes this slower
than the previous version.

It is necessary, however, because it resolves several problems. Specifically, it
fixes support for classes which contain other classes inside them. As part of a
later effort, it should be possible to improve the performance.

It is still being debugged, but I am sharing for visibility.