### PR TITLE
Rename buildUnionObj to addUnionObjToEnv

### DIFF
--- a/src/TypeCheck/Common.hs
+++ b/src/TypeCheck/Common.hs
@@ -47,27 +47,23 @@ type Pnt = Int
 data EnvDef = DefVar VarMeta | DefKnown Type
   deriving (Show, Generic, Hashable, ToJSON)
 type EnvValMap = (H.HashMap String EnvDef)
-data FEnv = FEnv { fePnts          :: IM.IntMap Scheme
-                 , feCons          :: [Constraint]
-                 , feUnionAllObjs  :: VarMeta -- union of all TypeObj for argument inference
-                 , feUnionTypeObjs :: VarMeta -- union of all Object types for function limiting
-                 , feVTypeGraph    :: VTypeGraph
-                 , feTTypeGraph    :: TTypeGraph
-                 , feClassMap      :: ClassMap
-                 , feDefMap        :: EnvValMap
-                 , feTrace         :: TraceConstrain
+data FEnv = FEnv { fePnts         :: IM.IntMap Scheme
+                 , feCons         :: [Constraint]
+                 , feUnionAllObjs :: VarMeta -- union of all TypeObj for argument inference
+                 , feVTypeGraph   :: VTypeGraph
+                 , feTTypeGraph   :: TTypeGraph
+                 , feClassMap     :: ClassMap
+                 , feDefMap       :: EnvValMap
+                 , feTrace        :: TraceConstrain
                  } deriving (Show)
 
 type UnionObj = (Pnt, Pnt) -- a union of all TypeObj for argument inference, union of all Object types for function limiting
-
-data BoundObjs = BoundAllObjs | BoundTypeObjs
-  deriving (Eq, Ord, Show, Generic, Hashable, ToJSON)
 
 data Constraint
   = EqualsKnown VarMeta Type
   | EqPoints VarMeta VarMeta
   | BoundedByKnown VarMeta Type
-  | BoundedByObjs BoundObjs VarMeta
+  | BoundedByObjs VarMeta
   | ArrowTo VarMeta VarMeta -- ArrowTo src dest
   | PropEq (VarMeta, ArgName) VarMeta
   | VarEq (VarMeta, TypeVarName) VarMeta
@@ -81,7 +77,7 @@ data SConstraint
   = SEqualsKnown Scheme Type
   | SEqPoints Scheme Scheme
   | SBoundedByKnown Scheme Type
-  | SBoundedByObjs BoundObjs Scheme
+  | SBoundedByObjs Scheme
   | SArrowTo Scheme Scheme
   | SPropEq (Scheme, ArgName) Scheme
   | SVarEq (Scheme, TypeVarName) Scheme
@@ -202,7 +198,7 @@ instance Show SConstraint where
   show (SEqualsKnown s t) = printf "%s == %s" (show s) (show t)
   show (SEqPoints s1 s2) = printf "%s == %s" (show s1) (show s2)
   show (SBoundedByKnown s t) = printf "%s ⊆ %s" (show s) (show t)
-  show (SBoundedByObjs b s) = printf "%s %s" (show b) (show s)
+  show (SBoundedByObjs s) = printf "BoundedByObjs %s" (show s)
   show (SArrowTo f t) = printf "%s -> %s" (show t) (show f)
   show (SPropEq (s1, n) s2) = printf "(%s).%s == %s"  (show s1) n (show s2)
   show (SVarEq (s1, n) s2) = printf "(%s).%s == %s"  (show s1) n (show s2)

--- a/src/TypeCheck/Constrain.hs
+++ b/src/TypeCheck/Constrain.hs
@@ -164,12 +164,9 @@ executeConstraint env (BoundedByKnown subPnt boundTp) = do
       let subScheme' = fmap (\ub' -> SType ub' lb description) (tryIntersectTypes env ub boundTp "executeConstraint BoundedByKnown")
       let env' = setScheme env subPnt subScheme' "BoundedByKnown"
       ([], subScheme /= subScheme', env')
-executeConstraint env@FEnv{feUnionAllObjs, feUnionTypeObjs, feClassMap} cons@(BoundedByObjs bnd pnt) = do
+executeConstraint env@FEnv{feUnionAllObjs, feClassMap} cons@(BoundedByObjs pnt) = do
   let scheme = descriptor env pnt
-  let boundPnt = case bnd of
-        BoundAllObjs  -> feUnionAllObjs
-        BoundTypeObjs -> feUnionTypeObjs
-  let boundScheme = descriptor env boundPnt
+  let boundScheme = descriptor env feUnionAllObjs
   case sequenceT (scheme, boundScheme) of
     TypeCheckResE _ -> ([], False, env)
     TypeCheckResult _ (SType TopType _ _, _) -> ([cons], False, env)

--- a/src/TypeCheck/Decode.hs
+++ b/src/TypeCheck/Decode.hs
@@ -30,7 +30,7 @@ matchingConstraint :: FEnv -> VarMeta -> Constraint -> Bool
 matchingConstraint env p (EqualsKnown p2 _) = equivalent env p p2
 matchingConstraint env p (EqPoints p2 p3) = matchingConstraintHelper env p p2 p3
 matchingConstraint env p (BoundedByKnown p2 _) = equivalent env p p2
-matchingConstraint env p (BoundedByObjs _ p2) = equivalent env p p2
+matchingConstraint env p (BoundedByObjs p2) = equivalent env p p2
 matchingConstraint env p (ArrowTo p2 p3) = matchingConstraintHelper env p p2 p3
 matchingConstraint env p (PropEq (p2, _) p3) = matchingConstraintHelper env p p2 p3
 matchingConstraint env p (VarEq (p2, _) p3) = matchingConstraintHelper env p p2 p3

--- a/src/TypeCheck/Encode.hs
+++ b/src/TypeCheck/Encode.hs
@@ -29,7 +29,7 @@ import           Syntax.Prgm
 import           Syntax.Types
 import           Text.Printf
 import           TypeCheck.Common
-import           TypeCheck.TypeGraph (buildTypeEnv)
+import           TypeCheck.TypeGraph (addUnionObjToEnv)
 
 -- represents how a specified variables corresponds to the known types.
 -- It could be a lower bound, upper bound, or exact bound
@@ -265,5 +265,5 @@ fromPrgms env1 pprgms tprgms = do
   (vprgms, env4) <- mapMWithFEnv env3 fromPrgm pprgmsWithVObjs
   let (vjoinObjMap, _, _) = mergePrgms vprgms
   let (tjoinObjMap, _, _) = mergePrgms tprgms
-  let env5 = buildTypeEnv env4 vjoinObjMap tjoinObjMap
+  let env5 = addUnionObjToEnv env4 vjoinObjMap tjoinObjMap
   return (vprgms, env5)

--- a/src/TypeCheck/Encode.hs
+++ b/src/TypeCheck/Encode.hs
@@ -41,7 +41,6 @@ makeBaseFEnv classMap = FEnv{
   fePnts = IM.empty,
   feCons = [],
   feUnionAllObjs = VarMeta 0 emptyMetaN Nothing,
-  feUnionTypeObjs = VarMeta 0 emptyMetaN Nothing,
   feVTypeGraph = H.empty,
   feTTypeGraph = H.empty,
   feClassMap = classMap,
@@ -116,7 +115,7 @@ fromExpr objArgs obj env1 (ITupleApply m (baseM, baseExpr) (Just argName) argExp
   let convertExprMeta' = VarMeta convertExprMeta (PreTyped TopType (labelPos "convert" $ getMetaPos $ getExprMeta argExpr)) obj
   let constraints = [ArrowTo (getExprMeta baseExpr') baseM',
                      AddArg (baseM', argName) m',
-                     BoundedByObjs BoundAllObjs m',
+                     BoundedByObjs m',
                      ArrowTo (getExprMeta argExpr') convertExprMeta',
                      PropEq (m', argName) convertExprMeta'
                     ]
@@ -131,7 +130,7 @@ fromExpr objArgs obj env1 (ITupleApply m (baseM, baseExpr) Nothing argExpr) = do
   let convertExprMeta' = VarMeta convertExprMeta (PreTyped TopType (labelPos "convert" $ getMetaPos $ getExprMeta argExpr)) obj
   let constraints = [ArrowTo (getExprMeta baseExpr') baseM',
                      AddInferArg baseM' m',
-                     BoundedByObjs BoundAllObjs m',
+                     BoundedByObjs m',
                      ArrowTo (getExprMeta argExpr') convertExprMeta'
                     ]
   let env7 = addConstraints env6 constraints
@@ -191,7 +190,7 @@ addObjArg fakeObj objM prefix varMap env (n, (m, maybeSubObj)) = do
         Just{}  -> BUpper
         Nothing -> BEq
   (m', env2) <- fromMeta env argBound (Just fakeObj) m prefix'
-  let env3 = addConstraints env2 [PropEq (objM, n) m', BoundedByObjs BoundAllObjs m']
+  let env3 = addConstraints env2 [PropEq (objM, n) m', BoundedByObjs m']
   let env4 = case H.lookup n varMap of
         Just varM -> addConstraints env3 [EqPoints m' varM]
         Nothing   -> env3
@@ -221,7 +220,7 @@ fromObject prefix isObjArg env (Object m basis name vars args doc path) = do
   let obj' = Object m' basis name vars' args' doc path
   (objValue, env4) <- fromMeta env3 BUpper (Just obj') (PreTyped (singletonType (PartialType (PTypeName name) H.empty H.empty H.empty PtArgExact)) (labelPos "objValue" $ getMetaPos m)) ("objValue" ++ name)
   let env5 = fInsert env4 name (DefVar objValue)
-  let env6 = addConstraints env5 [BoundedByObjs BoundAllObjs m' | isObjArg]
+  let env6 = addConstraints env5 [BoundedByObjs m' | isObjArg]
   let env7 = addConstraints env6 [BoundedByKnown m' (singletonType (PartialType (PTypeName name) (fmap (const TopType) vars) H.empty (fmap (const TopType) args) PtArgExact)) | basis == FunctionObj || basis == PatternObj]
   return (obj', env7)
 

--- a/src/TypeCheck/Show.hs
+++ b/src/TypeCheck/Show.hs
@@ -81,7 +81,7 @@ showCon :: FEnv -> Constraint -> SConstraint
 showCon env (EqualsKnown p t) = SEqualsKnown (descriptor env p) t
 showCon env (EqPoints p1 p2) = showConHelper env SEqPoints p1 p2
 showCon env (BoundedByKnown p t) = SBoundedByKnown (descriptor env p) t
-showCon env (BoundedByObjs b p) = SBoundedByObjs b (descriptor env p)
+showCon env (BoundedByObjs p) = SBoundedByObjs (descriptor env p)
 showCon env (ArrowTo p1 p2) = showConHelper env SArrowTo p1 p2
 showCon env (PropEq (p1, name) p2) = showConHelper env (\s1 s2 -> SPropEq (s1, name) s2) p1 p2
 showCon env (VarEq (p1, name) p2) = showConHelper env (\s1 s2 -> SVarEq (s1, name) s2) p1 p2


### PR DESCRIPTION
This does some minor simplification by removing old code and cleaning up
unnecessary pieces from the typegraph union obj.