### PR TITLE
Check pnt updates all in set Descriptor

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -140,3 +140,7 @@ isSubtypeOfWithObj classMap obj@Object{objVars} = isSubtypeOfWithEnv classMap (f
 
 isSubtypeOfWithObjSrc :: (Meta m) => ClassMap -> PartialType -> Object m -> Type -> Type -> Bool
 isSubtypeOfWithObjSrc classMap srcType obj@Object{objVars} = isSubtypeOfWithEnv classMap (fmap getMetaType objVars) (snd <$> formArgMetaMapWithSrc classMap obj srcType )
+
+isSubtypeOfWithMaybeObj :: (Meta m) => ClassMap -> Maybe (Object m) -> Type -> Type -> Bool
+isSubtypeOfWithMaybeObj classMap (Just obj) = isSubtypeOfWithObj classMap obj
+isSubtypeOfWithMaybeObj classMap Nothing    = isSubtypeOf classMap

--- a/src/TypeCheck/Encode.hs
+++ b/src/TypeCheck/Encode.hs
@@ -43,6 +43,7 @@ makeBaseFEnv classMap = FEnv{
   feUnionAllObjs = VarMeta 0 emptyMetaN Nothing,
   feVTypeGraph = H.empty,
   feTTypeGraph = H.empty,
+  feUpdatedDuringEpoch = False,
   feClassMap = classMap,
   feDefMap = H.empty,
   feTrace = [[]]

--- a/src/TypeCheck/Show.hs
+++ b/src/TypeCheck/Show.hs
@@ -98,3 +98,8 @@ showPrgm env (objMap, classMap, annots) = do
 
 showConstraints :: FEnv -> [Constraint] -> [SConstraint]
 showConstraints env = map (showCon env)
+
+showTraceConstrainEpoch :: FEnv -> TraceConstrainEpoch -> [(SConstraint, [(Pnt, Scheme)])]
+showTraceConstrainEpoch env = map mapConstraint . filter (not . null . snd)
+  where
+    mapConstraint (con, pnts) = (showCon env con, pnts)

--- a/src/TypeCheck/TypeGraph.hs
+++ b/src/TypeCheck/TypeGraph.hs
@@ -126,10 +126,6 @@ isSubtypePartialOfWithMaybeObj :: (Meta m) => ClassMap -> Maybe (Object m) -> Pa
 isSubtypePartialOfWithMaybeObj classMap (Just obj) = isSubtypePartialOfWithObj classMap obj
 isSubtypePartialOfWithMaybeObj classMap Nothing    = isSubtypePartialOf classMap
 
-isSubtypeOfWithMaybeObj :: (Meta m) => ClassMap -> Maybe (Object m) -> Type -> Type -> Bool
-isSubtypeOfWithMaybeObj classMap (Just obj) = isSubtypeOfWithObj classMap obj
-isSubtypeOfWithMaybeObj classMap Nothing    = isSubtypeOf classMap
-
 reachesHasCutSubtypeOf :: (Meta m) => ClassMap -> Maybe (Object m) -> ReachesTree -> Type -> Bool
 reachesHasCutSubtypeOf classMap mObj (ReachesTree children) superType = all childIsSubtype $ H.toList children
   where childIsSubtype (key, val) = isSubtypePartialOfWithMaybeObj classMap mObj key superType || reachesHasCutSubtypeOf classMap mObj val superType


### PR DESCRIPTION
This takes better advantage of the set descriptor method in env.common by moving
all checks for whether a scheme has changed there. This lets executeConstraint
and several other methods in Constrain become simpler.
Constrain

One other change is how the runLimit reached error is handled. Previously, it
ran another epoch to see what was still changing. This modifies it so that now
it simply prints out the latest trace of an epoch.