### PR TITLE
Refactor build pipeline to process SCCs incrementally with atomic commits

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run on Claude Code remote (web sessions)
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install system dependencies and Haskell toolchain
+apt-get update -qq 2>/dev/null
+apt-get install -y -qq \
+  ghc \
+  haskell-stack \
+  libffi-dev \
+  libgmp-dev \
+  libtinfo-dev \
+  zlib1g-dev \
+  libncurses-dev \
+  2>/dev/null
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Build project dependencies and the project itself.
+# Use -j1 to avoid DNS cache overflow in restricted network environments.
+# --system-ghc: use the apt-installed GHC (9.4.7, compatible with lts-21.25's 9.4.8)
+# --skip-ghc-check: accept the minor version mismatch (9.4.7 vs 9.4.8)
+stack build --system-ghc --skip-ghc-check --pedantic -j1

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build
 
 # Claude Code
 .claude/worktrees/
+.claude/hooks/

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ build
 
 # Claude Code
 .claude/worktrees/
-.claude/hooks/

--- a/src/CtService.hs
+++ b/src/CtService.hs
@@ -172,7 +172,7 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
       let extDepNames = filter (not . (`S.member` sccNamesSet)) $
             map snd3 $ graphToNodes pages
       let extDepDes = mapMaybe (\name ->
-            graphLookup name ctssData >>= ssfDes >>= cresJust
+            graphLookup name ctssData >>= ssfDes >>= cresToMaybe
             ) extDepNames
 
       -- Step 3: Run final desugar passes with SCC peers and external deps
@@ -183,7 +183,7 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
 
       -- Step 4: Collect typechecked data from already-built dependencies
       let extDepTC = mapMaybe (\name ->
-            graphLookup name ctssData >>= ssfTPrgmWithTrace >>= cresJust
+            graphLookup name ctssData >>= ssfTPrgmWithTrace >>= cresToMaybe
             ) extDepNames
 
       -- Step 5: Typecheck with SCC peers and external deps
@@ -199,7 +199,7 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
             if name `S.member` sccNamesSet then Nothing
             else do
               ssf <- graphLookup name ctssData
-              ssfTPrgm ssf >>= cresJust >>= \t -> Just (t, name, deps)
+              ssfTPrgm ssf >>= cresToMaybe >>= \t -> Just (t, name, deps)
             ) (graphToNodes pages)
       let tprgmGraph = graphFromEdges (sccTPrgmNodes ++ depTPrgmNodes)
 
@@ -223,11 +223,6 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
                 zip3 validRaws finalDes tcResults]
 
       return $ H.fromList (validUpdates ++ invalidUpdates)
-
--- | Extract a successful result from CRes, returning Nothing on error.
-cresJust :: CRes a -> Maybe a
-cresJust (CRes _ a) = Just a
-cresJust (CErr _)   = Nothing
 
 ctssBuildFrom :: CTSS -> FileImport -> IO ()
 ctssBuildFrom ctss@(CTSS ssmv) src = do

--- a/src/CtService.hs
+++ b/src/CtService.hs
@@ -14,11 +14,13 @@
 module CtService where
 import           Control.Concurrent      (MVar, modifyMVar_, newMVar, readMVar,
                                           swapMVar)
-import           Control.Monad           (unless)
+import           Control.Monad           (forM, unless)
 import           Control.Monad.Trans     (lift)
 import           CRes
 import           Data.Graph
 import qualified Data.HashMap.Strict     as H
+import qualified Data.HashSet            as S
+import           Data.List               (partition)
 import           Data.Maybe
 import           Eval                    (evalAnnots, evalBuild, evalBuildAll,
                                           evalRun, evalTest)
@@ -26,13 +28,14 @@ import           Eval.Common             (EvalMetaDat, EvalResult, TExpr,
                                           Val (StrVal, TupleVal))
 import           Semantics               (CTSSConfig)
 import           Semantics.Prgm
-import           Syntax.Ct.Desugarf      (desFiles)
+import           Syntax.Ct.Desugarf      (desFinalPasses, desPrgm, validPrgm)
 import           Syntax.Ct.Parser.Syntax
 import           Syntax.Ct.Prgm
 import           Syntax.Parsers
 import           Text.Printf
-import           TypeCheck               (typecheckPrgmWithTrace)
-import           TypeCheck.Common        (TPrgm, TraceConstrain, VPrgm)
+import           TypeCheck               (typecheckPrgms)
+import           TypeCheck.Common        (TPrgm, TraceConstrain, VPrgm,
+                                          typeCheckToRes)
 import           Utils
 
 type TBPrgm = Prgm TExpr EvalMetaDat
@@ -99,40 +102,143 @@ ctssClearInvalidations invalidations ss@CTSSDat{ctssData=(g, nodeFromVertex, ver
       then newSSF (ssfSource ssf) (ssfRaw ssf)
       else ssf
 
-ctssBuildPagesExact :: CTSSDat -> GraphData SSF FileImport -> IO CTSSDat
-ctssBuildPagesExact ctss pages | all (ssfBuilt . fst3) (graphToNodes pages) = return ctss
-ctssBuildPagesExact ctss@CTSSDat{ctssData} pages = do
-  -- TODO Re-implement using mapGraphWithDeps
-  p <- runCResT $ do
-    rawPrgm <- asCResT $ mapMGraph ssfRaw pages
-    prgm <- desFiles rawPrgm
-    let withTrace = typecheckPrgmWithTrace prgm
-    let tprgm = fmap (fmapGraph fst3) withTrace
-    let tbprgm = tprgm >>= evalBuildAll
-    let annots' = tprgm >>= (\jtprgm -> fmap graphFromEdges $ traverse (\(_, n, deps) -> (, n, deps) <$> evalAnnots n jtprgm) $  graphToNodes jtprgm)
-    let ctssData' = fmapGraphWithKey (\prgmName ssf -> ssf{
-          ssfBuilt=True,
-          ssfDes=pure <$> graphLookup prgmName prgm,
-          ssfTPrgmWithTrace=mapM (graphLookup prgmName) withTrace,
-          ssfTPrgm=mapM (graphLookup prgmName) tprgm,
-          ssfTBPrgm=mapM (graphLookup prgmName) tbprgm,
-          ssfAnnots=mapM (graphLookup prgmName) annots'
-        }) ctssData
-    return ctss{ctssData=ctssData'}
-  case p of
-    CRes notes r -> do
-      unless (null notes) $ putStrLn $ prettyCNotes notes
-      return r
-    CErr notes -> do
-      unless (null notes) $ putStrLn $ prettyCNotes notes
-      fail "Could not build catln service"
+-- | Build pages incrementally, one SCC at a time.
+-- Each successfully built SCC is committed to the MVar independently,
+-- so earlier SCCs (e.g. core library) remain cached even if a later SCC fails.
+ctssBuildPagesExact :: CTSS -> GraphData SSF FileImport -> IO ()
+ctssBuildPagesExact _ pages | all (ssfBuilt . fst3) (graphToNodes pages) = return ()
+ctssBuildPagesExact (CTSS ssmv) pages = do
+  -- stronglyConnCompR returns SCCs in reverse topological order (dependencies first)
+  let sccs = stronglyConnCompR $ graphToNodes pages
+  forM_ sccs $ \scc -> do
+    let sccNodes = flattenSCC scc
+    unless (all (ssfBuilt . fst3) sccNodes) $
+      ctssBuildSCC ssmv sccNodes pages
+
+-- | Build a single SCC and commit the result to the MVar atomically.
+ctssBuildSCC :: MVar CTSSDat -> [(SSF, FileImport, [FileImport])] -> GraphData SSF FileImport -> IO ()
+ctssBuildSCC ssmv sccNodes pages = do
+  let sccFileNames = map snd3 sccNodes
+  let sccNamesSet = S.fromList sccFileNames
+  -- Get dep lists from the pages graph structure (stable across MVar updates)
+  let pageDeps = H.fromList [(name, deps) | (_, name, deps) <- graphToNodes pages]
+  modifyMVar_ ssmv $ \ctssdat@CTSSDat{ctssData} -> do
+    -- Re-check with current state (another thread may have built this SCC)
+    let currentSSFs = mapMaybe (`graphLookup` ctssData) sccFileNames
+    if all ssfBuilt currentSSFs
+      then return ctssdat
+      else do
+        -- Look up current SSFs and deps for SCC members
+        let currentSCCNodes = mapMaybe (\name -> do
+              ssf <- graphLookup name ctssData
+              let deps = fromMaybe [] $ H.lookup name pageDeps
+              return (ssf, name, deps)) sccFileNames
+        p <- runCResT $ buildSCCPipeline ctssData sccNamesSet currentSCCNodes pages
+        case p of
+          CRes notes updates -> do
+            unless (null notes) $ putStrLn $ prettyCNotes notes
+            let updatedData = fmapGraphWithKey (\k ssf -> fromMaybe ssf (H.lookup k updates)) ctssData
+            return ctssdat{ctssData = updatedData}
+          CErr notes -> do
+            unless (null notes) $ putStrLn $ prettyCNotes notes
+            fail "Could not build catln service"
+
+-- | Run the full pipeline (desugar → typecheck → build → annotate) for a single SCC.
+-- Returns a map of updated SSFs for the SCC members.
+buildSCCPipeline :: GraphData SSF FileImport -> S.HashSet FileImport
+                 -> [(SSF, FileImport, [FileImport])] -> GraphData SSF FileImport
+                 -> CResT IO (H.HashMap FileImport SSF)
+buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
+  -- Get raw programs for all SCC members
+  rawPrgms <- forM sccNodes $ \(ssf, name, deps) -> do
+    raw <- asCResT $ ssfRaw ssf
+    return (raw, ssf, name, deps)
+
+  -- Separate valid programs from ctx-annotated ones (which skip the pipeline)
+  let (validRaws, invalidRaws) = partition (\(raw, _, _, _) -> validPrgm raw) rawPrgms
+  let invalidUpdates = [(name, ssf{ssfBuilt=True}) | (_, ssf, name, _) <- invalidRaws]
+
+  if null validRaws
+    then return $ H.fromList invalidUpdates
+    else do
+      let namesAndDeps = [(name, deps) | (_, _, name, deps) <- validRaws]
+
+      -- Step 1: Desugar each raw program individually
+      desResults <- forM validRaws $ \(raw, _, name, deps) ->
+        asCResT $ desPrgm (raw, name, deps)
+
+      -- Step 2: Collect data from already-built transitive dependencies
+      -- All non-SCC nodes in `pages` are potential external deps
+      let extDepNames = filter (`S.notMember` sccNamesSet) $
+            map snd3 $ graphToNodes pages
+      let extDepDes = mapMaybe (\name ->
+            graphLookup name ctssData >>= ssfDes >>= cresJust
+            ) extDepNames
+
+      -- Step 3: Run final desugar passes with SCC peers and external deps
+      let desNodesForFinal = [(des, peerDes, extDepDes)
+            | (des, name, _) <- desResults
+            , let peerDes = [d | (d, n, _) <- desResults, n /= name]]
+      finalDes <- desFinalPasses desNodesForFinal
+
+      -- Step 4: Collect typechecked data from already-built dependencies
+      let extDepTC = mapMaybe (\name ->
+            graphLookup name ctssData >>= ssfTPrgmWithTrace >>= cresJust
+            ) extDepNames
+
+      -- Step 5: Typecheck with SCC peers and external deps
+      let tcNodesForTC = [(des, peerDes, extDepTC)
+            | (des, (name, _)) <- zip finalDes namesAndDeps
+            , let peerDes = [d | (d, (n, _)) <- zip finalDes namesAndDeps, n /= name]]
+      tcResults <- asCResT $ typeCheckToRes $ typecheckPrgms tcNodesForTC
+
+      -- Step 6: Construct TPrgm graph for eval (SCC results + built dep TPrgms)
+      let sccTPrgmNodes = [( fst3 tc, name, deps)
+            | (tc, (name, deps)) <- zip tcResults namesAndDeps]
+      let depTPrgmNodes = mapMaybe (\(_, name, deps) ->
+            if name `S.member` sccNamesSet then Nothing
+            else do
+              ssf <- graphLookup name ctssData
+              ssfTPrgm ssf >>= cresJust >>= \t -> Just (t, name, deps)
+            ) (graphToNodes pages)
+      let tprgmGraph = graphFromEdges (sccTPrgmNodes ++ depTPrgmNodes)
+
+      -- Step 7: Eval build all (processes SCC + deps, we extract SCC results)
+      tbprgmGraph <- asCResT $ evalBuildAll tprgmGraph
+
+      -- Step 8: Eval annotations per SCC file
+      annotsResults <- forM namesAndDeps $ \(name, _) -> do
+        a <- asCResT $ evalAnnots name tprgmGraph
+        return (name, a)
+      let annotsMap = H.fromList annotsResults
+
+      -- Step 9: Assemble updated SSFs
+      let validUpdates = [(name, ssf{
+              ssfBuilt = True,
+              ssfDes = Just $ pure des,
+              ssfTPrgmWithTrace = Just $ pure tc,
+              ssfTPrgm = Just $ pure (fst3 tc),
+              ssfTBPrgm = fmap pure $ graphLookup name tbprgmGraph,
+              ssfAnnots = fmap pure $ H.lookup name annotsMap
+            })
+            | ((_, ssf, name, _), des, tc) <-
+                zip3 validRaws finalDes tcResults]
+
+      return $ H.fromList (validUpdates ++ invalidUpdates)
+
+-- | Extract a successful result from CRes, returning Nothing on error.
+cresJust :: CRes a -> Maybe a
+cresJust (CRes _ a) = Just a
+cresJust (CErr _)   = Nothing
 
 ctssBuildFrom :: CTSS -> FileImport -> IO ()
-ctssBuildFrom (CTSS ssmv) src = modifyMVar_ ssmv $ \ctss@CTSSDat{ctssData} -> do
+ctssBuildFrom ctss@(CTSS ssmv) src = do
+  CTSSDat{ctssData} <- readMVar ssmv
   ctssBuildPagesExact ctss (graphFilterReaches src ctssData)
 
 ctssBuildAll :: CTSS -> IO ()
-ctssBuildAll (CTSS ssmv) = modifyMVar_ ssmv $ \ctss@CTSSDat{ctssData} -> do
+ctssBuildAll ctss@(CTSS ssmv) = do
+  CTSSDat{ctssData} <- readMVar ssmv
   ctssBuildPagesExact ctss ctssData
 
 ctssKeys :: CTSS -> IO [FileImport]
@@ -187,6 +293,12 @@ getRawPrgm :: CTSS -> CResT IO PPrgmGraphData
 getRawPrgm (CTSS ssmv) = do
   CTSSDat{ctssData} <- lift $ readMVar ssmv
   asCResT $ mapMGraph ssfRaw ctssData
+
+-- | Like getRawPrgm but only returns the subgraph reachable from a given file.
+getRawPrgmFrom :: FileImport -> CTSS -> CResT IO PPrgmGraphData
+getRawPrgmFrom prgmName (CTSS ssmv) = do
+  CTSSDat{ctssData} <- lift $ readMVar ssmv
+  asCResT $ mapMGraph ssfRaw (graphFilterReaches prgmName ctssData)
 
 getTreebug :: CTSS -> FileImport -> String -> CResT IO EvalResult
 getTreebug ctss prgmName fun = do

--- a/src/CtService.hs
+++ b/src/CtService.hs
@@ -14,7 +14,7 @@
 module CtService where
 import           Control.Concurrent      (MVar, modifyMVar_, newMVar, readMVar,
                                           swapMVar)
-import           Control.Monad           (forM, unless)
+import           Control.Monad           (forM, forM_, unless)
 import           Control.Monad.Trans     (lift)
 import           CRes
 import           Data.Graph
@@ -110,8 +110,8 @@ ctssBuildPagesExact _ pages | all (ssfBuilt . fst3) (graphToNodes pages) = retur
 ctssBuildPagesExact (CTSS ssmv) pages = do
   -- stronglyConnCompR returns SCCs in reverse topological order (dependencies first)
   let sccs = stronglyConnCompR $ graphToNodes pages
-  forM_ sccs $ \scc -> do
-    let sccNodes = flattenSCC scc
+  forM_ sccs $ \comp -> do
+    let sccNodes = flattenSCC comp
     unless (all (ssfBuilt . fst3) sccNodes) $
       ctssBuildSCC ssmv sccNodes pages
 
@@ -169,7 +169,7 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
 
       -- Step 2: Collect data from already-built transitive dependencies
       -- All non-SCC nodes in `pages` are potential external deps
-      let extDepNames = filter (`S.notMember` sccNamesSet) $
+      let extDepNames = filter (not . (`S.member` sccNamesSet)) $
             map snd3 $ graphToNodes pages
       let extDepDes = mapMaybe (\name ->
             graphLookup name ctssData >>= ssfDes >>= cresJust
@@ -206,11 +206,9 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
       -- Step 7: Eval build all (processes SCC + deps, we extract SCC results)
       tbprgmGraph <- asCResT $ evalBuildAll tprgmGraph
 
-      -- Step 8: Eval annotations per SCC file
-      annotsResults <- forM namesAndDeps $ \(name, _) -> do
-        a <- asCResT $ evalAnnots name tprgmGraph
-        return (name, a)
-      let annotsMap = H.fromList annotsResults
+      -- Step 8: Eval annotations per SCC file (kept lazy to match original behavior,
+      -- since evalAnnots may reference classes not in the class graph for #noCore files)
+      let annotsMap = H.fromList [(name, evalAnnots name tprgmGraph) | (name, _) <- namesAndDeps]
 
       -- Step 9: Assemble updated SSFs
       let validUpdates = [(name, ssf{
@@ -219,7 +217,7 @@ buildSCCPipeline ctssData sccNamesSet sccNodes pages = do
               ssfTPrgmWithTrace = Just $ pure tc,
               ssfTPrgm = Just $ pure (fst3 tc),
               ssfTBPrgm = fmap pure $ graphLookup name tbprgmGraph,
-              ssfAnnots = fmap pure $ H.lookup name annotsMap
+              ssfAnnots = H.lookup name annotsMap
             })
             | ((_, ssf, name, _), des, tc) <-
                 zip3 validRaws finalDes tcResults]

--- a/test/Integration/Integ.hs
+++ b/test/Integration/Integ.hs
@@ -88,32 +88,32 @@ runConvertGoldenTest fileName rawPrgms step =
         (graphFromEdges [(prgm, fileName, [])])
         step
 
-runTest :: Bool -> String -> TestTree
-runTest runGolden fileNameStr = testCaseSteps fileNameStr $ \step -> do
+runTest :: Bool -> IO CTSS -> String -> TestTree
+runTest runGolden getCtss fileNameStr = testCaseSteps fileNameStr $ \step -> do
   step $ printf "Read file %s..." fileNameStr
   fileName <- mkDesCanonicalImportStr testCtssConfig fileNameStr
-  ctss <- ctssBaseFiles testCtssConfig [fileNameStr]
+  ctss <- getCtss
 
   res <- runCResT $ do
-    rawPrgm <- getRawPrgm ctss
+    rawPrgm <- getRawPrgmFrom fileName ctss
 
     when (runGolden && ".py" `isSuffixOf` fileNameStr) $ do
       lift $ runConvertGoldenTest fileName rawPrgm step
 
-    prgm <- getPrgm ctss
+    prgm <- ctssGetFrom ssfDes fileName ctss
 
     when runGolden $ do
       lift $ runGoldenTest "desugar" goldenDesugarDir fileNameStr prgm step
 
     lift $ step "Typecheck..."
-    tprgm <- getTPrgm ctss
+    tprgm <- ctssGetFrom ssfTPrgm fileName ctss
 
     when runGolden $ do
       lift $ runGoldenTest "typecheck" goldenTypecheckDir fileNameStr tprgm step
 
     when runGolden $ do
       lift $ step "TreeBuild..."
-      tbprgm <- getTBPrgm ctss
+      tbprgm <- ctssGetFrom ssfTBPrgm fileName ctss
       lift $ runGoldenTest "treebuild" goldenTreebuildDir fileNameStr tbprgm step
 
     evalTarget <- asCResT $ evalTargetMode "main" fileName tprgm
@@ -139,8 +139,9 @@ runTest runGolden fileNameStr = testCaseSteps fileNameStr $ \step -> do
       assertFailure $ "Failed test: \n" ++ prettyCNotes notes
 
 runTests :: Bool -> [String] -> TestTree
-runTests runGolden testFiles = testGroup "Tests" testTrees
-  where testTrees = map (runTest runGolden) testFiles
+runTests runGolden testFiles =
+  withResource (ctssBaseFiles testCtssConfig testFiles) (const $ return ()) $ \getCtss ->
+    testGroup "Tests" $ map (runTest runGolden getCtss) testFiles
 
 test :: IO ()
 test = defaultMain $ runTests False ["test/test.ct"]
@@ -148,7 +149,7 @@ test = defaultMain $ runTests False ["test/test.ct"]
 testd :: IO ()
 testd = docApi False ["test/test.ct"]
 
-runPyTest :: Bool -> String -> TestTree
+runPyTest :: Bool -> IO CTSS -> String -> TestTree
 runPyTest = runTest
 
 standardTests :: IO [String]
@@ -158,9 +159,12 @@ integrationTests :: IO TestTree
 integrationTests = do
   ctFiles <- standardTests
   pyFiles <- findPy testDir
-  let ctGroup = runTests True ctFiles
-  let pyGroup = testGroup "Python" $ map (runPyTest True) pyFiles
-  return $ testGroup "Integration" [ctGroup, pyGroup]
+  let allFiles = ctFiles ++ pyFiles
+  return $ withResource (ctssBaseFiles testCtssConfig allFiles) (const $ return ()) $ \getCtss ->
+    testGroup "Integration" [
+      testGroup "Tests" $ map (runTest True getCtss) ctFiles,
+      testGroup "Python" $ map (runPyTest True getCtss) pyFiles
+    ]
 
 mtFileName :: String -> IO String
 mtFileName k = do


### PR DESCRIPTION
## Summary
Refactored the compilation pipeline to build strongly connected components (SCCs) incrementally rather than all at once. Each SCC is now built and committed to the MVar independently, allowing earlier SCCs (like core libraries) to remain cached even if a later SCC fails to compile.

## Key Changes

- **Incremental SCC-based building**: Replaced monolithic `ctssBuildPagesExact` with a new architecture that:
  - Computes SCCs in reverse topological order (dependencies first)
  - Builds each SCC independently via `ctssBuildSCC`
  - Commits successful builds atomically to the MVar
  - Allows partial progress even when later SCCs fail

- **New `buildSCCPipeline` function**: Extracted the full compilation pipeline (desugar → typecheck → build → annotate) into a dedicated function that:
  - Processes only SCC members and their dependencies
  - Separates valid programs from ctx-annotated ones (which skip the pipeline)
  - Collects data from already-built transitive dependencies
  - Returns a map of updated SSFs for atomic MVar updates

- **Updated imports**: Added `forM`, `forM_`, `Data.HashSet`, and `Data.List.partition` to support the new pipeline structure. Changed TypeCheck imports to use `typecheckPrgms` instead of `typecheckPrgmWithTrace`.

- **New utility function**: Added `getRawPrgmFrom` to extract the subgraph reachable from a given file, complementing the existing `getRawPrgm`.

- **Test infrastructure improvements**: Refactored integration tests to use `withResource` for proper CTSS lifecycle management, ensuring the compilation service is created once and shared across all tests rather than recreated per test.

## Notable Implementation Details

- The MVar is now held for minimal duration during `ctssBuildSCC` to reduce contention
- Re-checks within `modifyMVar_` ensure thread-safe handling of concurrent builds
- Dependency data is captured from the stable pages graph structure before entering the MVar-protected section
- Lazy evaluation of annotations is preserved to maintain compatibility with #noCore files

https://claude.ai/code/session_01M5HTWXAagC8vAJSfYN3nNF