### PR TITLE
Add blank lines between definition groups in formatter

### DIFF
--- a/src/Syntax/Ct/Formatter.hs
+++ b/src/Syntax/Ct/Formatter.hs
@@ -145,24 +145,52 @@ isHiddenStatement (RawAnnot annot) | isElseAnnot annot = True
 isHiddenStatement (RawAnnot annot) | isCtxAnnot annot = True
 isHiddenStatement _ = False
 
+isHiddenStatementTree :: RawStatementTree RawExpr m -> Bool
+isHiddenStatementTree (RawStatementTree stmt _) = isHiddenStatement stmt
+
+isAnnotStatementTree :: RawStatementTree RawExpr m -> Bool
+isAnnotStatementTree (RawStatementTree (RawAnnot _) _) = True
+isAnnotStatementTree _                                 = False
+
+-- | Get the object path of a statement's LHS declaration, if present
+stmtObjPath :: RawStatementTree RawExpr m -> Maybe TypeName
+stmtObjPath (RawStatementTree (RawDeclStatement RawObjArr{roaObj = Just obj}) _) = maybeExprPath obj
+stmtObjPath (RawStatementTree (RawBindStatement RawObjArr{roaObj = Just obj}) _) = maybeExprPath obj
+stmtObjPath _                                                                    = Nothing
+
+-- | Returns True if a blank line should be inserted between two consecutive statements.
+-- Annotations are kept together with adjacent statements (no blank line before/after).
+-- Blank lines separate groups of definitions with different object paths.
+needsBlankLine :: RawStatementTree RawExpr m -> RawStatementTree RawExpr m -> Bool
+needsBlankLine prev curr
+  | isHiddenStatementTree prev = False
+  | isHiddenStatementTree curr = False
+  | isAnnotStatementTree prev  = False
+  | isAnnotStatementTree curr  = True
+  | otherwise = case (stmtObjPath prev, stmtObjPath curr) of
+      (Just p1, Just p2) -> p1 /= p2
+      _                  -> False
+
+-- | Format a list of statements, inserting blank lines between groups
+formatStatementTrees :: (MetaDat m, Show m) => Bool -> Int -> [RawStatementTree RawExpr m] -> Builder
+formatStatementTrees rootStatement indent stmts =
+  forM_ (zip (Nothing : map Just stmts) stmts) $ \(mprev, s) -> do
+    case mprev of
+      Nothing   -> return ()
+      Just prev -> when (needsBlankLine prev s) (literal "\n")
+    formatStatementTree rootStatement indent s
+
 formatStatementTree :: (MetaDat m, Show m) => Bool -> Int -> RawStatementTree RawExpr m -> Builder
 formatStatementTree rootStatement indent (RawStatementTree statement subTree) = do
   unless (isHiddenStatement statement) (literal $ formatStatement indent statement)
-
-  -- Check if the subTree should also be a rootStatement with an additional ending newline
   let subTreeRootStatement = rootStatement && keepRootStatement statement
-
-  forM_ subTree $ \s -> do
-    formatStatementTree subTreeRootStatement (indent + 1) s
-  when rootStatement ""
+  formatStatementTrees subTreeRootStatement (indent + 1) subTree
 
 formatPrgm :: (MetaDat m, Show m) => Int -> RawPrgm m -> Builder
 formatPrgm indent (RawPrgm imports statements) = do
-  forM_ imports $ \imp -> do
-    formatImport imp
+  forM_ imports formatImport
   unless (null imports) "\n"
-  forM_ statements $ \s -> do
-    formatStatementTree True indent s
+  formatStatementTrees True indent statements
 
 formatRootPrgm :: (MetaDat m, Show m) => RawPrgm m -> String
 formatRootPrgm = build . formatPrgm 0

--- a/stack/approx/approx.ctx
+++ b/stack/approx/approx.ctx
@@ -1,8 +1,9 @@
+import "core"
+
 
 # # Approximation
   Approximation is a fundamental primitive to bridge the gap between idealism and reality.
   It is a combination of several concepts: probaility, uncertainty, and obviously approximation.
-
 class(Approx[$T])
   # The basic idea of [Approx] is fairly simple.
     You have an object of type [$T], but you don't quite know which element of [$T] it is.
@@ -16,17 +17,18 @@ class(Approx[$T])
     The other level of knowledge is runtime-level.
     This contains probabilities or uncertainties that are not figured out until runtime.
     For example, if you are playing a game and learn your roll is >3, it changes the precision of the approximation.
-
 class(Probability, [Num_from(0)_until(1)])
-
 class(Prob, [Probability])
   class(Distribution[$T], isa= [Approx[$T]])
     # A [Probability/Distribution] is a function that ascribes a probability to every possible value.
+
   :Distribution.get(x -> $T) -> Prob
+
   testDistributionNormalized(d -> Distribution[$T]) =
     #test
     #assert(enum[$T].map(f(x)= d.get(x)).sum == 1)
     ()
+
   data(Fun[$T](p(x -> $T) -> Prob))
     :Fun(p).get(x)= p(x)
 
@@ -37,13 +39,11 @@ data(LiftApprox[$T](val -> $T), isa= [Approx[$T]])
   (val :: $T) | $T ~:: Approx -> Approx[$T]= LiftApprox(val= val)
     # Any non-approximation can be turned into an approximation by wrapping it in the LiftApprox.
       This allows mixing operations between approximations and non-approximations.
+
   :LiftApprox.isPerfect= True
 
 class(ProbMap[$T], [ProbMap/Unnormalized[$T](vals) | (sum(vals) == 1)])
 
 data(ProbMap/Unnormalized[$T](vals -> Map[$T, Probability]), isa= [Approx[$T], Distribution[$T]])
-
 :ProbMap/Unnormalized(vals)
-
 :ProbMap.get(x)= vals.get(x, default= 0)
-

--- a/stack/core/algebra.ct
+++ b/stack/core/algebra.ct
@@ -13,8 +13,10 @@ module(Data/Algebra)
     # /operator==</Data/Algebra/Eq $T>($T l, $T r) -> Boolean
     # This checks whether two items are equal.
       Note that it only compares like items with each other, not that you can compare apples to oranges.
+
   (_ :: $T != _ :: $T)[$T -> /Data/Algebra/Eq] -> Boolean
     # This checks if two items are not equal.
+
   # It is the opposite of [operator==] leading to the simple definition:
   # /operator!=(l, r) = ~(l == r)
     Given this, creating an instance of Eq only requires defining equality and the != can be produced automatically.
@@ -25,7 +27,9 @@ module(Data/Algebra)
   class(Ord)
     # Ord is used to define types which can be strictly ordered.
       Every element, when compared must have one of the following [Ordering] relationships:
+
   every(Number, isa= [/Data/Algebra/Ord])
+
   class(Ordering, [LessThan, Equal, GreaterThan])
     # The Orderings can relate any like items of Ord. 
   class(POrd)
@@ -36,23 +40,31 @@ module(Data/Algebra)
       One set A <= B when A is a subset of B.
       An ordered example is {1} <= {1, 2}.
       But, two sets like {1} and {2} have no ordering between them.
+
   # There are a few nice properties about ordering.
   every(Ord, isa= [/Data/Algebra/POrd])
+
   # This means that something fully ordered can still take advantage of many of the same functions as partially ordered ones.
     It just usually has a more specific result.
   compare[$T -> Ord](l -> $T, r -> $T) -> Ordering
   compare[$T -> POrd](l -> $T, r -> $T) -> POrdering
+
   # The only major function for ordering is [compare].
     Comparing two [Ord] will result in an [Ordering].
     Likewise, comparing two partially orderables [POrd] results in a [POrdering].
   # ### Operators for ordering
     Besides compare, there are also some operators to make using ordering easier.
   (_ :: $T <= _ :: $T)[$T -> Ord] -> Boolean
+
   (_ :: $T >= _ :: $T)[$T -> Ord] -> Boolean
+
   (_ :: $T < _ :: $T)[$T -> Ord] -> Boolean
+
   (_ :: $T > _ :: $T)[$T -> Ord] -> Boolean
+
   every(POrd, isa= [/Data/Algebra/Eq])
     # If something can be compared for order, it should also be comparable for equality by the following relationship:
+
   # /operator==<POrd $T>($T l, $T r) = compare(l=l, r=r) == Equal
   # ### Ordering utility functions
   # max<Ord $T>($T l, $T r) -> $T = if l >= r then l else r
@@ -62,25 +74,33 @@ module(Data/Algebra)
   class(Semigroup)
     # A semigroup is a type combined with an associative operation called [operator++].
       For example, integers with the addition operation are a semigroup.
+
   every(Semigroup, isa= [/Data/Algebra/Eq])
+
   (_ :: $T ++ _ :: $T)[$T -> Semigroup] -> $T
+
   testSemigroupAssociative[$T -> Semigroup](a -> $T, b -> $T, c -> $T) =
     #test
     #assert(test= (a ++ b) ++ c == a ++ (b ++ c))
     0
+
   class(Monoid)
     # The [Monoid] builds on top of the [Semigroup].
       It adds the identity value [mempty].
       The integers with addition form a [Monoid], and 0 is the value for [mempty].
       Another example is [String] where "" is the value for [mempty]
+
   every(Monoid, isa= [/Data/Algebra/Semigroup])
+
   mempty[$T -> Monoid] -> $T
     # mempty is the "zero" or "empty" value that can be combined with [operator++] to result in the same operation
+
   # We can test to verify that [mempty] works with both the left and right.
   #test
     testRightMonoidIdentity[$T -> /Data/Algebra/Monoid](t -> $T) =
       #assert(test= (t ++ mempty) == t)
       0
+
     testLeftMonoidIdentity[$T -> /Data/Algebra/Monoid](t -> $T) =
       #assert(test= mempty ++ t == t)
       0
@@ -90,24 +110,29 @@ module(Data/Algebra)
     # The [CommutativeMonoid] builds on top of the [Monoid].
       It is also called an Abelian Monoid
       Here, integers with addition are a [CommutativeMonoid], but [String]s are not.
+
   every(CommutativeMonoid, isa= [/Data/Algebra/Monoid])
+
   # We can test to ensure that all [CommutativeMonoid]s satisfy the commutativity requirement.
   testCommutativeMonoid[$T -> /Data/Algebra/CommutativeMonoid](a -> $T, b -> $T) =
     #test
     #assert(test= a ++ b == b ++ a)
     0
+
   class(Group)
     # The [Group] builds on top of the [Monoid] (not necessarily the [CommutativeMonoid]).
       It adds an inverse operation that finds the opposite of an element.
       For integers with addition, negation with [operator~] would be the inverse.
       Something like [String]s would not have an inverse, so it wouldn't be a [Group].
+
   every(Group, isa= [/Data/Algebra/Monoid])
+
   inverse[$T -> Group](t -> $T) -> $T
     # We can test to ensure that all [Group]s satisfy the inverse requirements.
       An inverse times itself should result in [mempty].
+
   testGroup[$T -> Group](t -> $T) =
     #test
     #assert(test= t ++ inverse(t= t) == mempty)
     #assert(test= inverse(t= t) ++ t == mempty)
     0
-

--- a/stack/core/compile.ct
+++ b/stack/core/compile.ct
@@ -12,12 +12,15 @@ module(Catln)
       The [IO] type is also special because it is the only truly impure type in the language.
       Files and external values can change unexpectedly.
       But, all of the impurity is managed in this single type.
+
   :IO.exit(val -> Integer) -> IO
     # [exit] will immediately terminate the process and return [val] as the status value.
     #runtime("ioExit")
+
   :IO.println(msg -> String) -> IO
     # [println] will print the [msg] to the standard output along with a newline character.
     #runtime("println")
+
   # ## Core Annotations
     The core annotations are all of the annotations used by the compiler and the web docs program.
   annot(#md(text -> String))
@@ -67,23 +70,29 @@ module(Catln)
   annot(#eximport(name -> String))
     # [#eximport] is used to mark exported items from Haskell modules.
       When a Haskell module has an explicit export list, this annotation indicates which items are re-exported.
+
   # ## Build-in Type Macros
   (_ ?-> _) -> Boolean
     #runtime("arrExists")
+
   # ## Result Classes
   data(CatlnResult(name -> String, contents -> String))
     # The [CatlnResult] represents the result of a catln build.
       The most typical results are compiled executables.
       But, they could also be other kinds of results such as websites or cloud configurations.
       Any global value which has type [CatlnResult] can be called through `catln build [FILE] [VALUE]`.
+
   www(html -> String)= CatlnResult(name= "index.html", contents= html)
     # [www] is used to build web results.
+
   llvm(c) -> CatlnResult..
     # [llvm] runs the [LLVM Compiler](https://llvm.org/) to build the runnable argument [c] into a [CatlnResult] executable.
     #runtime("llvm")
+
   data(/Catln/classPlaceholder[$T])
     # [classPlaceholder] is used internally to represent a class with no elements.
       It ensures that expanding an empty class does not produce the empty set.
+
   class(ThenElse, [Then, Else])
     fromBool(v -> Boolean) -> ThenElse
     fromBool(v= /Data/Primitive/True)= Then

--- a/stack/core/data.ct
+++ b/stack/core/data.ct
@@ -7,13 +7,17 @@ module(Data)
   # ## String
   data(String)
     # A [String] is a list of characters.
+
   every(String, isa= [/Data/Algebra/Eq])
+
   (_ :: String == _ :: String) -> Boolean
     #runtime("strEq")
+
   :String.toString -> String
   :String.toString= this
   :Integer.toString -> String
     #runtime("intToString")
+
   # ## Context
   data(/Context[$V](value -> $V, .._))
     # The context is used to represent state.
@@ -21,61 +25,83 @@ module(Data)
     # The [ContextIn] is used to represent an input state in a function.
   data(/ContextOut[$V](value -> $V, .._))
     # The [ContextOut] is used to represent an output state in a function.
+
   /Context[$V, $T](value -> $V, .._) | (/ContextIn[$V -> $V](value= (_ :: $V), .._) ?-> (_ :: $T)) -> $T
     #runtime("context")
+
   # ## Collections
     Collections are contains that hold elements of a type inside them.
   class(Functor[$T])
     # A [Functor] is a basic property of a collection.
       It has a single operation [fmap] that applies a function to each element in the collection.
     # $F[$A: $T].fmap[$F: Functor](fn(v: $A) -> $B) -> $F[$B: $T]
+
   # ## Collections
   class(Option[$T], [$T, None])
     # [Option] defines a type that might have a value or [None].
       It can be used to handle operations that are uncertain if they can produce a response.
+
   every(Option[$T -> $T], isa= [/Data/Functor])
+
   # None.fmap(fn) = None
   # $T.fmap(fn($T)) = fn(this)
   class(List[$T])
+
   # A [List] is a collection of zero or more ordered items.
   class(ConsList[$T], [Cons[$T -> $T](head -> $T, tail -> ConsList[$T -> $T]), Nil])
     # The simplest kind of list can be created by prepending.
       A [ConsList] defines a list either by prepending to a list or with an empty list.
+
   every(ConsList[$T -> $T], isa= [/Data/List[$T -> $T]])
+
   # /operator+:<$T>($T l, ConsList<$T> r) = Cons(head=l, tail=r)
     [operator+:] is a utility operator to prepend an element onto a [List].
   # #### [length]
     The [length] of a [List] is the number of items inside of it.
   :Nil.length= 0
   /Data/Cons(head, tail).length= 1 + tail.length
+
   # ## List operations
   sum(lst -> /Data/List) -> Integer
+
   all(lst -> /Data/List) -> Boolean
+
   any(lst -> /Data/List) -> Boolean
+
   reversed(lst -> /Data/List) -> /Data/List
+
   sorted(lst -> /Data/List) -> /Data/List
+
   # ## ConsList runtime operations
   sum(lst -> ConsList) -> Integer
     #runtime("listSum")
+
   all(lst -> ConsList) -> Boolean
     #runtime("listAll")
+
   any(lst -> ConsList) -> Boolean
     #runtime("listAny")
+
   reversed(lst -> ConsList) -> ConsList
     #runtime("listReversed")
+
   sorted(lst -> ConsList) -> ConsList
     #runtime("listSorted")
+
   range(stop -> Integer) -> ConsList
     #runtime("listRange")
+
   every(ConsList[$T -> $T], isa= [/Data/Functor])
+
   # Nil.fmap(fn) = Nil
   # Cons(head, tail).fmap(fn) = Cons(head=fn(head), tail=tail.fmap(fn))
   class(Set[$T])
+
   # A [Set] is a collection of zero or more unique items.
     It is not ordered.
   class(Enum)
     # [Enum] represents a type which can be enumerated.
       It defines a single function [enum] which lists all of the values in the type.
+
   enum[$T -> Enum] -> Set[$T]
     # [enum] lists all of the values in a type.
-

--- a/stack/core/main.ct
+++ b/stack/core/main.ct
@@ -9,4 +9,3 @@ import "core/webdoc.ct"
   This is the Catln core library.
   It defines the fundamental units of the language, core data types, basic compilation, and standard methods.
   All Catln files will automatically import the core library.
-

--- a/stack/core/primitives.ct
+++ b/stack/core/primitives.ct
@@ -13,97 +13,135 @@ module(Data/Primitive)
       It is a type that has only a single element.
       Therefore, no information is presented through it's use.
       It is often used for void return values.
+
   # ## Booleans
   class(Boolean, [True, False])
+
   every(Boolean, isa= [/Data/Algebra/Eq])
+
   (_ :: Boolean == _ :: Boolean) -> Boolean
   (_ :: True == _ :: True)= True
   (_ :: True == _ :: False)= False
   (_ :: False == _ :: True)= False
   (_ :: False == _ :: False)= True
+
   (~(_ :: Boolean)) -> Boolean
   (~(_ :: True))= False
   (~(_ :: False))= True
+
   (_ :: Boolean && _ :: Boolean) -> Boolean
   (_ :: True && _ :: True)= True
   (_ :: Boolean && _ :: False)= False
   (_ :: False && _ :: Boolean)= False
+
   (_ :: Boolean || _ :: Boolean) -> Boolean
   (_ :: True || _ :: Boolean)= True
   (_ :: Boolean || _ :: True)= True
   (_ :: False || _ :: False)= False
+
   (_ :: Boolean ^ _ :: Boolean) -> Boolean
   (_ :: True ^ _ :: True)= False
   (_ :: True ^ _ :: False)= True
   (_ :: False ^ _ :: True)= True
   (_ :: False ^ _ :: False)= False
+
   every(Boolean, isa= [/Data/Enum])
+
   # enum<Boolean> = [False, True]
   # ## Integers
   class(Number, [Integer, Float])
+
   every(Number, isa= [/Data/Algebra/Eq])
+
   (-(_ :: Integer)) -> Integer
     #runtime("intNeg")
   (_ :: Integer - _ :: Integer) -> Integer
     #runtime("int-")
+
   (_ :: Integer + _ :: Integer) -> Integer
     #runtime("int+")
+
   (_ :: Integer * _ :: Integer) -> Integer
     #runtime("int*")
+
   (_ :: Integer % _ :: Integer) -> Integer
     #runtime("int%")
+
   (_ :: Integer <= _ :: Integer) -> Boolean
     #runtime("int<=")
+
   (_ :: Integer >= _ :: Integer) -> Boolean
     #runtime("int>=")
+
   (_ :: Integer < _ :: Integer) -> Boolean
     #runtime("int<")
+
   (_ :: Integer > _ :: Integer) -> Boolean
     #runtime("int>")
+
   (_ :: Integer == _ :: Integer) -> Boolean
     #runtime("int==")
+
   (_ :: Integer != _ :: Integer) -> Boolean
     #runtime("int!=")
+
   # ### Commutative Group
   every(Integer, isa= [/Data/Algebra/CommutativeMonoid])
   every(Integer, isa= [/Data/Algebra/Group])
+
   exampleZeroPlusZero =
     #example
     #assert(test= 0 + 0 == 0)
     0
-  mempty -> Integer = 0
+
+  mempty -> Integer= 0
+
   (_ :: Integer ++ _ :: Integer) -> Integer
     #runtime("int+")
-  inverse(t -> Integer) -> Integer = -t
+
+  inverse(t -> Integer) -> Integer= -t
+
   (_ :: Integer // _ :: Integer) -> Integer
     #runtime("intDiv")
+
   # ## Floats
   (-(_ :: Float)) -> Float
     #runtime("floatNeg")
   (_ :: Float - _ :: Float) -> Float
     #runtime("float-")
+
   (_ :: Float + _ :: Float) -> Float
     #runtime("float+")
+
   (_ :: Float * _ :: Float) -> Float
     #runtime("float*")
+
   (_ :: Float // _ :: Float) -> Float
     #runtime("float//")
+
   (_ :: Float <= _ :: Float) -> Boolean
     #runtime("float<=")
+
   (_ :: Float >= _ :: Float) -> Boolean
     #runtime("float>=")
+
   (_ :: Float < _ :: Float) -> Boolean
     #runtime("float<")
+
   (_ :: Float > _ :: Float) -> Boolean
     #runtime("float>")
+
   (_ :: Float == _ :: Float) -> Boolean
     #runtime("float==")
+
   (_ :: Float != _ :: Float) -> Boolean
     #runtime("float!=")
+
   :Float.round -> Integer
     #runtime("floatRound")
+
   :Float.floor -> Integer
     #runtime("floatFloor")
+
   :Float.ceil -> Integer
     #runtime("floatCeil")
-

--- a/stack/core/webdoc.ct
+++ b/stack/core/webdoc.ct
@@ -7,32 +7,56 @@ module(Catln/Doc)
     These include the ones
   class(DShow)
     # Represents objects which can be shown in the webdocs.
+
   # dshow(s) -> /Catln/Doc/DShow
   dshow(s -> DShow)= s
+
   every(String, isa= [/Catln/Doc/DShow])
   every(CatlnResult.., isa= [/Catln/Doc/DShow])
+
   data(Show/MD(text -> String))
+
   every(Show/MD.., isa= [/Catln/Doc/DShow])
+
   dshow(s= #md(text))= Show/MD(text= text)
   dshow(s= #print(p))= p
-  annot(#listProgram)
-  data(Show/ListProgram)
-  every(Show/ListProgram.., isa= [/Catln/Doc/DShow])
-  dshow(s= #listProgram)= Show/ListProgram
-  annot(#type)
-  data(Show/TypePage)
-  every(Show/TypePage.., isa= [/Catln/Doc/DShow])
-  dshow(s= #type)= Show/TypePage
-  annot(#typeInfer)
-  data(Show/TypeInfer)
-  every(Show/TypeInfer.., isa= [/Catln/Doc/DShow])
-  dshow(s= #typeInfer)= Show/TypeInfer
-  annot(#debug)
-  data(Show/Debug)
-  every(Show/Debug.., isa= [/Catln/Doc/DShow])
-  dshow(s= #debug)= Show/Debug
-  annot(#build)
-  data(Show/BuildPage)
-  every(Show/BuildPage.., isa= [/Catln/Doc/DShow])
-  dshow(s= #build)= Show/BuildPage
 
+  annot(#listProgram)
+
+  data(Show/ListProgram)
+
+  every(Show/ListProgram.., isa= [/Catln/Doc/DShow])
+
+  dshow(s= #listProgram)= Show/ListProgram
+
+  annot(#type)
+
+  data(Show/TypePage)
+
+  every(Show/TypePage.., isa= [/Catln/Doc/DShow])
+
+  dshow(s= #type)= Show/TypePage
+
+  annot(#typeInfer)
+
+  data(Show/TypeInfer)
+
+  every(Show/TypeInfer.., isa= [/Catln/Doc/DShow])
+
+  dshow(s= #typeInfer)= Show/TypeInfer
+
+  annot(#debug)
+
+  data(Show/Debug)
+
+  every(Show/Debug.., isa= [/Catln/Doc/DShow])
+
+  dshow(s= #debug)= Show/Debug
+
+  annot(#build)
+
+  data(Show/BuildPage)
+
+  every(Show/BuildPage.., isa= [/Catln/Doc/DShow])
+
+  dshow(s= #build)= Show/BuildPage

--- a/stack/error/main.ctx
+++ b/stack/error/main.ctx
@@ -1,29 +1,39 @@
+import "core"
+
 
 # Error Handling
   When performing operations, it is sometimes possible for errors to occur.
   Those errors are represented using [Err].
-
 class(Err)
   # The only basic expected data for an [Err] is [msg].
   :Err.msg -> String
+
   # The standard way of creating an [Err] is by calling [err]
   error(#msg -> String, cause -> Optional[Err] ? Nothing) -> Err= Basic(msg= msg, cause= cause)
+
   data(Basic(msg -> String, cause -> Optional[Err]))
+
   # This allows for the [error.#msg] to be overridden with greater contextual understanding.
   apply(a"${fun} > error")
     #msg("An error occurred when running [fun]")
   apply(a"${fun} > error(cause -> Err)")
     #msg("An error occurred when running [fun] due to [cause]")
+
   class(Result[$R, $E -> Err], [$R, $E])
     # The standard handling of the [Err] is by wrapping things into a [Result].
     :Result[$R, $E].default(def -> $R)= match(this)
       val -> $R= val
+
       _ :: $E= def
+
     every(Result[$R -> $T, $E], isa= [Functor])
+
     :Result[$R, $E].map(f)= match(this)
       val -> $R= f(val)
+
       e -> $E= e
+
     :Result[$R].to[Optional]= match(this)
       val -> $R= val
-      _ :: $E= Nothing
 
+      _ :: $E= Nothing

--- a/stack/int/int.ctx
+++ b/stack/int/int.ctx
@@ -1,11 +1,15 @@
-# # Int
+import "core"
 
+
+# # Int
 class(Int)
   data(Zero)
+
   class(Peano, [Succ(i= Peano), Zero], isa= [Int])
     class(One, [Succ(Zero)])
     class(Two, [Succ(Succ(Zero))])
   class(NPeano, [Pred(i= NPeano), Zero], isa= [Int])
+
   # ## Equality
   (Zero == Zero)= True
   (_ :: Succ(_) == Zero)= False
@@ -16,7 +20,9 @@ class(Int)
   (_ :: Succ(_) == Pred(_))= False
   (Succ(l) == Succ(r))= (l == r)
   (Pred(l) == Pred(r))= (l == r)
+
   (l :: Int != r :: Int)= ~(l == r)
+
   # ## Comparison
   (_ :: Peano < Zero)= False
   (Zero < Succ(_))= True
@@ -24,27 +30,42 @@ class(Int)
   (Succ(_) < Pred(_))= False
   (Succ(l) < Succ(r))= l < r
   (Pred(l) < Pred(r))= l < r
+
   (l :: Int > r :: Int)= r < l
+
   (Zero <= Zero)= True
   (Succ(_) <= Zero)= False
   (Zero <= Succ(_))= True
   (Pred(_) <= _ :: Peano)= True
   (Succ(_) <= Pred(_))= False
+
   (l :: Int >= r :: Int)= r <= l
+
   (~(l :: Int < r :: Int))= l >= r
   (~(l :: Int <= r :: Int))= l > r
   (~(l :: Int > r :: Int))= l <= r
   (~(l :: Int >= r :: Int))= l < r
+
   (l :: Int < r :: Int) | l == r= l <= r
+
   (l :: Int > r :: Int) | l == r= l >= r
+
   :Int.gt(r -> Int)= this > r
+
   :Int.lt(r -> Int)= this < r
+
   :Int.gte(r -> Int)= this >= r
+
   :Int.lte(r -> Int)= this <= r
+
   :Peano.gte(0)= True
+
   :Peano.lt(0)= False
+
   :NPeano.lte(0)= True
+
   :NPeano.gt(0)= False
+
   # ## Addition
   (l :: Peano + Zero)= l
   (l :: NPeano + Zero)= l
@@ -64,15 +85,19 @@ class(Int)
   (i :: Int + Pred(_)) -> Int__lt(i)
   (_ :: NPeano + i :: Int) -> Int__lte(i)
   (Pred(_) + i :: Int) -> Int__lt(i)
+
   # ## Negation and Subtraction
   (-Zero)= Zero
   (-Succ(i))= Pred(-i)
   (-Pred(i))= Succ(-i)
   (-(-(i)))= i
   (l :: Int - r :: Int)= l + (-r)
+
   # ## Increment and Decrement
   :Int.inc -> Int= :Int + 1
+
   :Int.dec -> Int= :Int - 1
+
   # ## Multiplication
   (Zero * _ :: Int)= Zero
   (_ :: Int * Zero)= Zero
@@ -84,33 +109,46 @@ class(Int)
   (l :: NPeano * r :: Int)= -((-l) * r)
   (l :: Int * r :: NPeano)= -(l * (-r))
   (l :: NPeano * r :: NPeano)= -((-l) * (-r))
+
   # ## Division
   data(Division(dividend -> Int, divisor -> Int, quotient -> Int, remainder -> Int))
+
   (_ :: Peano // _ :: Int__gt(0)) -> Division
   (dividend :: Int // divisor :: Int)= if(dividend < divisor)
     Then= Division(dividend= dividend, divisor= divisor, quotient= 0, remainder= dividend)
+
     Else= (dividend - divisor // divisor)(dividend= dividend, quotient= inc(quotient))
+
   # ## Skewed Int
   data(Skewed(m -> ConstantInt__gt(0), x -> Int, b -> ConstantInt), isa= [Int])
     # A utility for [Int] that represents something like [`m*x+b`].
       It can be used to help avoid unnecessary computations and to fit [x] into a smaller data type.
+
   Skewed(m, x, b) -> Int= m * x + b
     # If desired, can be converted into a full [Int] at any point.
   :Int -> Skewed= Skewed(m= 1, x= :Int, b= 0)
     # Any [Int] can be lifted into a [Skewed] to allow operations containing both.
+
   # Comparisons and equality
   (Skewed(m, x= x1, b) == Skewed(m, x= x2, b))= x1 == x2
+
   (Skewed(m, x= x1, b) < Skewed(m, x= x2, b))= x1 < x2
+
   (Skewed(m, x= x1, b) <= Skewed(m, x= x2, b))= x1 <= x2
+
   # Addition and Subtraction
   (i :: ConstantInt__multipleOf(m) + s@Skewed(m, x, b))= s(b= b + (i // m))
   (s@Skewed(m, x, b) + i :: ConstantInt__multipleOf(m))= s(b= b + (i // m))
+
   (-Skewed(m, x, b))= Skewed(m= m, x= -x, b= -b)
+
   # Multiplication
   (i :: ConstantInt * s@Skewed(m, x, b))= s(m= m * i)
   (s@Skewed(m, x, b) * i :: ConstantInt)= s(m= m * i)
+
   # Division
   (s@Skewed(m, x, b) // i :: ConstantInt__factorOf(m))= s(m= m // i)
+
   # ## Even
   even(n -> Int) -> Boolean
   even(Zero)= True
@@ -118,4 +156,3 @@ class(Int)
   even(Pred(n))= ~even(n)
   even(l + r | even(l) && even(r)) -> True
     #refine
-

--- a/stack/list/fun.ctx
+++ b/stack/list/fun.ctx
@@ -1,14 +1,14 @@
+import "core"
 import "iterator.ctx"
 
 
-
 # # Function List
-
 module(Data/List)
   data(FunList[$T](length -> Int, f(x -> Int_from(0)_to(length)) -> $T))
     # A virtual [List] represented by a function.
       Similarly to the [Iterator], it can act as a glue between [List] types and operations.
       However, it applies only to randomly accessible lists and to parallel operations.
+
   every(FunList[$T], isa= [List[$T]])
 
 FunList[$T](length, f) -> Iterator[$T -> $T] =
@@ -16,9 +16,9 @@ FunList[$T](length, f) -> Iterator[$T -> $T] =
   f2(x -> Int_from(0)_to(length)) -> IteratorResult
   f2(x= length)= IteratorDone
   f2(x -> Int_lt(length))= IteratorNext(nextState= x + 1, val= f(x))
+
   Iterator(length= length, f= f2)
 
 :FunList[$T](length, f= f1).map(f(x -> $T) -> $T2= f2)= FunList[$T2](length= length, f(x)= f2(f1(x)))
   # One useful aspect of the [FunList] is that it allows deferring map operations.
     Here, we can use the map to create a variant [FunList] that applies both functions.
-

--- a/stack/list/iterator.ctx
+++ b/stack/list/iterator.ctx
@@ -1,8 +1,10 @@
+import "core"
+
 
 # # Iterator List
-
 module(Data/List)
   class(IteratorResult[$T, $State], [IteratorNext(nextState -> $State, val -> $T), IteratorDone])
+
   data(Iterator[$T, $State](length -> Int, initState -> $State, f(x -> $State) -> IteratorResult[$T= $T, $State= $State]))
     # A virtual [List] represented by an iterator.
       The iterator has an internal state of type [$State] and by applying [f] it produces the next value of the iterator and a next state.
@@ -15,7 +17,9 @@ every(Iterator[$T], isa= [List[$T]])
   f2(x -> $State) =
     match(f(x))
       IteratorNext(nextState, val)= (nextState, mapFun(val))
+
       IteratorDone= IteratorDone
+
   Iterator[$T= $T2, $State= $State](length= length, initState= initState, f= f2)
 
 :Iterator[$T, $State](length, initState, f).flatMap(f= mapFun) =
@@ -23,11 +27,15 @@ every(Iterator[$T], isa= [List[$T]])
     _<- imperative
     _<- returns
     state<- var(x)
+
     while(state.().vals.length < 0)
       _<- match(f(state.().s))
         IteratorNext(nextState, val)= state := (vals= mapFun(val), s= nextState)
-        IteratorDone= return(IteratorDone)
-    (vals= v + :vs, s)= state.()
-    return(IteratorNext(nextState= (vals= vs, s= s)), val= v)
-  Iterator[$T -> $T2, $State= (vals= List[$T -> $T2], s= $State)](length= length, initState= initState, f= f2)
 
+        IteratorDone= return(IteratorDone)
+
+    (vals= v + :vs, s)= state.()
+
+    return(IteratorNext(nextState= (vals= vs, s= s)), val= v)
+
+  Iterator[$T -> $T2, $State= (vals= List[$T -> $T2], s= $State)](length= length, initState= initState, f= f2)

--- a/stack/list/op/filter.ctx
+++ b/stack/list/op/filter.ctx
@@ -1,32 +1,25 @@
+import "core"
+
 
 # # Filtering
   The filter is a basic higher-order operation on a [List].
   It will apply a predicate function to the [List] and keep only the operations that pass the predicate.
   Here is an example:
-
 > [1, 2, 3, 4, 5].filter(even)
-
 :List[$T].filter(f(x -> $T) -> Bool) -> List[$T]
-
 :List[$T].filter(f= predicate)= this.flatMap(f(x)= predicate(x).if(then= [x], else= []))
   # The simplest definition of filter can be done in terms of the [flatMap] operation.
 
 # In addition, there are a number of useful refinements to [filter].
-
 #refinement
   :List[$T].filter(f(x -> $T) -> True)= this
     # If the list is passed a predicate which is always [True], then it returns the main list.
-
   :List[$T].filter(f(x -> $T) -> False)= []
     # If the list is passed a predicate which is always [False], then it returns nothing.
-
   :List_size(size).filter(f) -> List_size(Int_lte(size))
     # As [filter] only removes elements from the list, we know that the resulting list has at most the same size
-
   :List[$T].filter(f(x -> $T) -> Bool) -> (List[$T2 -> $T] | f(x :: $T2) ?-> True)
     # The type of the filtered list is not exactly the same as the input list.
       Only the type of elements that pass the predicate can be found in the filtered list.
       In the example earlier, we filter based on even numbers.
       Therefore, we know that the filtered list contains not just [Int], but more precisely [Int_even].
-
-

--- a/stack/list/sparse.ctx
+++ b/stack/list/sparse.ctx
@@ -1,14 +1,13 @@
+import "core"
 import "iterator.ctx"
 
 
-
 # # Sparse List
-
 module(Data/List)
   data(Sparse[$T](length -> Int, def -> $T, vals -> Map[$K= Int_from(0)_to(length), $V= $T]))
     # A sparse list with a default value [def] for all values not specified in the value map [vals].
       It is best used when the list is expected to have very few non-default values.
+
   every(Sparse[$T], isa= [List[$T]])
 
 :Sparse[$T](length, def, vals).map(f(x -> $T) -> $T2)= Sparse[$T2](length= length, def= f(def), vals= vals.map(f))
-

--- a/stack/llvm/compile.ctx
+++ b/stack/llvm/compile.ctx
@@ -1,10 +1,12 @@
+import "core"
+
 
 # LLVM Compiler
   This package is a compiler based on the [LLVM Compiler Infrastructure](https://llvm.org/).
-
 module(LLVM)
   class(Expr[$T])
     # Used to represent expression-equivalent data.
+
   data(Operand[$T](repr -> String), isa= [Expr[$T]])
     # An operand is an expression value in [LLVM].
       The most common is a register storing values and typically represented like `%1`.
@@ -16,16 +18,19 @@ module(LLVM)
     # ## Constant Expressions
     expr(:ConstantTrue)= Operand[Bool]("true")
     expr(:ConstantFalse)= Operand[Bool]("false")
+
     # ### Unsigned int
     expr(i -> ConstantInt__from(0)__until(2 ^ 8))= Operand[Int]("i8 " ++ i)
     expr(i -> ConstantInt__from(0)__until(2 ^ 16))= Operand[Int]("i16 " ++ i)
     expr(i -> ConstantInt__from(0)__until(2 ^ 32))= Operand[Int]("i32 " ++ i)
     expr(i -> ConstantInt__from(0)__until(2 ^ 64))= Operand[Int]("i64 " ++ i)
+
     # ### Signed int
     expr(i -> ConstantInt__from(-2 ^ 7)__until(2 ^ 7))= Operand[Int]("i8 " ++ i)
     expr(i -> ConstantInt__from(-2 ^ 15)__until(2 ^ 15))= Operand[Int]("i16 " ++ i)
     expr(i -> ConstantInt__from(-2 ^ 31)__until(2 ^ 16))= Operand[Int]("i32 " ++ i)
     expr(i -> ConstantInt__from(-2 ^ 63)__until(2 ^ 32))= Operand[Int]("i64 " ++ i)
+
   # ## Apply Implicit Conversions
   :Expr[$T1 -> $T2] -> Expr[$T]= implicit[$T2](this)
     # Applies an implicit convesion to an expression to typecheck
@@ -34,24 +39,32 @@ module(LLVM)
       Includes several options such as strict, lazy, and async.
     implicit[$T2](e -> Expr[$T1]){}= implicitBase[$T](e)
       #name("strict")
+
   # ## Lazyness
   class(LazyData[$T1, $T2], [LazyUncomputed[$T2](e -> $T1), LazyComputed(v -> Expr[$T2])], isa= [Expr[$T2]])
+
   data(LazyExpr[$T1, $T2](val -> Var[LazyData[$T1= $T1, $T2= $T2]]))
+
   implicit[$T2](e){} =
     #name("lazy")
     d<- var[LazyData](LazyUncomputed[$T2](e))
+
     LazyExpr(val= d)
+
   LazyExpr[$T2](val) -> Operand[$T2] =
     v<- val.()
     _<- match(v)
       LazyComputed(v)= v
+
       LazyUncomputed(e) =
         res<- implicitBase[$T2](e)
+
         val := LazyComputed(v= res)
+
         res
+
   # ## implicitBase Calls
   implicitBase[$T2](e -> Expr[$T1 -> $T2]){} -> Expr[$T2]
     # This looks up the claimed implicit(s).
       There can be multiple if they are partial or have conditions.
       Then, it will match as necessary and call the base functions.
-

--- a/stack/math/log.ctx
+++ b/stack/math/log.ctx
@@ -1,6 +1,7 @@
+import "core"
+
 
 # # Logarithms and Exponents
-
 :Num.log -> Num
   # The natural logarithm of a number.
 
@@ -8,15 +9,12 @@
   # The exponent of a number
 
 # The natural logarithm and exponent are opposites and counter each other out
-
 :Num.log.exp= this
 
 :Num.exp.log= this
 
 # One useful strategy is to use logarithms as a representation for numbers, especially probabilities.
   It is advantageous because it allows them to be represented with better and converts multiplications into cheapter additions.
-
 (l :: Num_from(0)_to(1) * r :: Num_from(0)_to(1))= (l.log + r.log).exp
 
 :List[Num_from(0)_to(1)].prod= this.map(f(x)= x.log).sum.exp
-

--- a/stack/memory/main.ctx
+++ b/stack/memory/main.ctx
@@ -1,3 +1,5 @@
+import "core"
+
 
 # # Memory
   The [Memory] is designed to work as part of [Context].
@@ -10,42 +12,54 @@
   Imperative code is defined by the usage of [Memory].
   However, [Memory] is not a fundamental aspect and shouldn't be built-in.
   Instead, using it as a library helps to bridge it with other concepts, but still enables the same programming strategies as imperative languages.
-
 class(Memory[$V -> Var])
   # The basic class [Memory] should be put inside the [Context] to enable memory-based programming.
   class(Var[$T])
     # The class representing a variable within the [Memory].
       If you think of the [Memory] as a map, then the [Var] is a key.
+
   var[$T]{:Memory} -> Var[$T]{Memory}
     # Creates a new undefined variable
   var[$T](v -> $T){:Memory} -> Var[$T]{Memory}
     # Creates a new variable with the initial value of [v].
+
   free(v -> Var){:Memory} -> (){Memory}
     # Removes a variable from memory, potentially reclaiming the memory to be reused.
+
   :Var[$T].(){:Memory} -> $T{Memory}
     # Gets the value of the variable [this] from memory.
   (:Var[$T] := val -> $T){:Memory} -> $T{Memory}
     # Sets a variale in [Memory] and replaces the previous value.
+
   :Memory.vars -> Set[Var]
     # Lists the vars within [this] [Memory]
+
   # ## [MemoryMap]
   data(MemoryMap(:Map[$K= VarInt, $V= Optional], counter -> Int), isa= [Memory])
     # The [MemoryMap] is one of the simplest [Memory] that implements it using a [Map].
       While most [Memory] are built using things like hardware or external services, this helps make sure that [Memory] can be used wherever.
     Empty= MemoryMap(map= Empty, counter= 0)
+
     data(VarInt[$T](:Int))
+
     var[$T]{:MemoryMap} =
       i= :MemoryMap.counter
+
       v= VarInt[$T](i)
       v{MemoryMap(map= :MemoryMap.map.insert(v, Nothing), counter= i + 1)}
     var[$T](v){:MemoryMap} =
       i= :MemoryMap.counter
+
       v= VarInt[$T](i)
       v{MemoryMap(map= :MemoryMap.map.insert(v, v), counter= i + 1)}
+
     free(v -> Var){:MemoryMap}= (){:MemoryMap(map= :MemoryMap.map.remove(v))}
+
     :Var[$T].(){:MemoryMap}= :MemoryMap.map.get(var)
     (:Var[$T] := val -> $T){:MemoryMap}= val{:MemoryMap(map= :MemoryMap.map.set(var, val))}
+
     :MemoryMap.vars= this.map.keys
+
   imperative{}(f{Memory} -> $R) -> $R
     # The imperative allows you to define an imperative block of code.
       The key goal is to enable support for imperative algorithms.
@@ -60,4 +74,3 @@ class(Memory[$V -> Var])
     #name("existing")
   imperative{~Memory}(f)= withContext(context= [MemoryMap/Empty], f= f)
     #name("map")
-

--- a/stack/ndarray/batch.ctx
+++ b/stack/ndarray/batch.ctx
@@ -1,9 +1,10 @@
+import "core"
+
 
 # # NDArray Batching
   With the [NDArray] class, it provides more reliable mechanisms by which [NDArray]s can be combined.
   This becomes important in a standard case of mapping.
   Oftentimes, it is possible to replace the outer loop from a map with [NDArray] opreations instead.
-
 module(Data/NDArray)
   class(StackBatchFun)
     # The most common form is that many functions on [NDArray] can be used with stack batching.
@@ -11,4 +12,3 @@ module(Data/NDArray)
 
 :List[$T -> NDArray].map(f -> StackBatchFun)= f(this.stack).split
   # In translation, the map can be replaced by stacking all of the [NDArray] together, applying the function to the stacked equivalent, and then unstacking them.
-

--- a/stack/ndarray/ndarray.ctx
+++ b/stack/ndarray/ndarray.ctx
@@ -1,20 +1,28 @@
+import "core"
+
 
 # # NDArray
-
 class(NDArray[$T])
   # The [NDArray] is a class containing an N-Dimensional array.
     It can be used to represent scalars, vectors, matrices, and higher-dimensional equivalents.
   class(Shape, [List[Int]])
     # A shape represents the dimensionality and sizes along each dimension.
       For example, a scalar is length 0, vector is length 1, matrix is length 2, etc.
+
   :NDArray.shape -> Shape
+
   :NDArray.size= this.shape.prod
     # The number of elements in the [NDArray]
+
   :NDArray[$T].flatten -> List[$T]
+
   data(ListNDArray/Invalid[$T](:Shape, flatten -> List[$T]))
+
   class(ListNDArray[$T], [ListNDArray/Invalid[$T] | (shape.prod == flatten.length)])
     # A simple definition for the 
-  :ListNDArray.size= this.flatten.size
-  every(NDArray[$T -> $T], isa= [Functor])
-  :NDArray.map(f)= ListNDArray(shape= this.shape, flatten= this.flatten.map(f))
 
+  :ListNDArray.size= this.flatten.size
+
+  every(NDArray[$T -> $T], isa= [Functor])
+
+  :NDArray.map(f)= ListNDArray(shape= this.shape, flatten= this.flatten.map(f))

--- a/stack/python/builtins.ct
+++ b/stack/python/builtins.ct
@@ -1,49 +1,66 @@
+import "core"
 import "core/data.ct"
+
 
 module(Python/Builtins)
   # ## IO built-ins
   :IO.input -> String
     #runtime("ioInput")
+
   # ## Python built-in abs and pow mapped to methods
   :Integer.abs -> Integer
     #runtime("intAbs")
   :Float.abs -> Float
     #runtime("floatAbs")
+
   :Integer.pow(exp -> Integer) -> Integer
     #runtime("intPow")
   :Float.pow(exp -> Float) -> Float
     #runtime("floatPow")
+
   # ## Type conversions
   :Float.toInt -> Integer
     #runtime("floatToInt")
+
   :Integer.toFloat -> Float
     #runtime("intToFloat")
+
   :Float.toString -> String
     #runtime("floatToString")
+
   :Integer.toBool -> Boolean
     #runtime("intToBool")
   :Float.toBool -> Boolean
     #runtime("floatToBool")
+
   # ## String operations
   chr(n -> Integer) -> String
     #runtime("intToChar")
+
   :String.ord -> Integer
     #runtime("strToOrd")
+
   :Integer.hex -> String
     #runtime("intToHex")
+
   :Integer.oct -> String
     #runtime("intToOct")
+
   :Integer.bin -> String
     #runtime("intToBin")
+
   (_ :: String + _ :: String) -> String
     #runtime("strConcat")
+
   :String.length -> Integer
     #runtime("strLength")
+
   # ## Numeric min/max
   max(l -> Integer, r -> Integer) -> Integer
     #runtime("intMax")
   max(l -> Float, r -> Float) -> Float
     #runtime("floatMax")
+
   min(l -> Integer, r -> Integer) -> Integer
     #runtime("intMin")
   min(l -> Float, r -> Float) -> Float

--- a/stack/web/http.ctx
+++ b/stack/web/http.ctx
@@ -1,8 +1,12 @@
+import "core"
+
 
 module(Web/Http)
   data(Request)
   data(Response(code -> Int, headers -> Bag[$T -> Response/Header], body -> Optional[$T -> String]))
-  server(f(request -> Request) -> Response)
-  class(Error)
-  Error.code -> Int
 
+  server(f(request -> Request) -> Response)
+
+  class(Error)
+
+  Error.code -> Int

--- a/stack/web/site.ctx
+++ b/stack/web/site.ctx
@@ -1,5 +1,5 @@
+import "core"
 import "web/http.ctx"
-
 
 
 module(Web)
@@ -7,19 +7,25 @@ module(Web)
     This defines some of the basic primitives for building a web site.
   data(Webpack(page -> Html, resources -> Map[$K -> String, $V -> File]))
     # [Html] refers to the HTML tag html.
+
   (page -> Html) -> Webpack= Webpack(page= page, resources= empty)
     # This interop converts an HTML page into a webpack
       It can be used to convert many of the HTML tag combining features into equivalent webpack combining.
       Especially when some are webpacks and others are merely HTML.
+
   Try[$R -> Webpack].to[Http/Response]= match(this)
     e -> Http/Error= Response(code= e.code, headers= empty, body= Nothing)
+
     w -> Webpack= Response(code= 200, headers= undefined, body= undefined)
+
   class(WebFunction)
     # A [WebFunction] is used to define a website
     WebFunction{} -> Try[$R -> Webpack]
       # All WebFunctions must be able to build the website
       # TODO: should pass in data to the function through some context which has not yet been defined.
+
     # TODO Add test forall webfunctions, the resources must be constant with respect to context inputs
+
   website(f -> WebFunction) -> Catln/Result
     # [website] produces an HTTP server that serves a site.
       The site can be defined using the page builder [f].
@@ -36,10 +42,10 @@ module(Web)
     httpFunction(request -> Request) =
       # TODO Add request into the function context
       f.to[Http/Response]
+
     Http/server(f= httpFunction)
   website(f)= undefined
     #name("singlePage")
     # The single page app uses client side rendering.
       This means that it can save time by avoiding many network calls.
       Even the necessary calls will be faster as they can transmit data in a denser format.
-

--- a/test/Integration/code/arith.ct
+++ b/test/Integration/code/arith.ct
@@ -1,5 +1,7 @@
-# Tests the various integer arithmetic operations
+import "core"
 
+
+# Tests the various integer arithmetic operations
 add= 1 + 1 == 2
 
 sub= 5 - 3 == 2

--- a/test/Integration/code/bool.ct
+++ b/test/Integration/code/bool.ct
@@ -1,5 +1,7 @@
-# Tests boolean logic operations
+import "core"
 
+
+# Tests boolean logic operations
 a= ~False
 
 b= True && True
@@ -11,4 +13,3 @@ main{io -> IO} =
   #assert(test= b)
   #assert(test= c)
   io
-

--- a/test/Integration/code/case.ct
+++ b/test/Integration/code/case.ct
@@ -1,8 +1,9 @@
-# Tests the case statement
+import "core"
 
+
+# Tests the case statement
 main{io -> IO}= io.exit(val= abs(0))
 
 abs(x -> Integer)= case(x)
   x2 | x >= 0= x2
   x2= x2 * -1
-

--- a/test/Integration/code/complex.ct
+++ b/test/Integration/code/complex.ct
@@ -1,8 +1,9 @@
-# Tests data classes and matching values in functions (c=Type(...)) without type vars
+import "core"
 
+
+# Tests data classes and matching values in functions (c=Type(...)) without type vars
 data(Complex(a -> Number, b -> Number))
 
 real(c= Complex(a, b))= a
 
 main{io -> IO}= io.exit(val= real(c= Complex(a= 0, b= 7)))
-

--- a/test/Integration/code/complexVar.ct
+++ b/test/Integration/code/complexVar.ct
@@ -1,8 +1,9 @@
-# Tests data classes and matching values in functions (c=Type(...)) with type vars
+import "core"
 
+
+# Tests data classes and matching values in functions (c=Type(...)) with type vars
 data(Complex[$N -> Number](a -> $N, b -> $N))
 
 real(c= Complex(a, b))= a
 
 main{io -> IO}= io.exit(val= real(c= Complex(a= 0, b= 7)))
-

--- a/test/Integration/code/cond.ct
+++ b/test/Integration/code/cond.ct
@@ -1,8 +1,8 @@
+import "core"
+
+
 # Tests using the conditions if and else guards for arrows
-
 abs(x -> Integer) | x >= 0= x
-
 abs(x -> Integer) else = x
 
 main{io -> IO}= io.exit(val= abs(0))
-

--- a/test/Integration/code/curry.ct
+++ b/test/Integration/code/curry.ct
@@ -1,12 +1,14 @@
-# Tests currying inner values
+import "core"
 
+
+# Tests currying inner values
 outerVar= 5 - 3 == 2
 
 f(io -> IO) =
   innerVar= 1 + 1 == 2
+
   #assert(test= outerVar)
   #assert(test= innerVar)
   io
 
 main{io -> IO}= f(io)
-

--- a/test/Integration/code/curryCtx.ct
+++ b/test/Integration/code/curryCtx.ct
@@ -1,10 +1,12 @@
-# Tests currying values with context
+import "core"
 
+
+# Tests currying values with context
 outerVar= 5 - 3 == 2
 
 main{io -> IO} =
   innerVar= 1 + 1 == 2
+
   #assert(test= outerVar)
   #assert(test= innerVar)
   io
-

--- a/test/Integration/code/fib.ct
+++ b/test/Integration/code/fib.ct
@@ -1,8 +1,8 @@
+import "core"
+
+
 # Tests recursion with fibonaccci
-
 fib(:Integer) | integer > 1= fib(integer= integer - 1) + fib(integer= integer - 2)
-
 fib(:Integer) else = 1
 
 main{io -> IO}= io.exit(val= fib(3) - 3)
-

--- a/test/Integration/code/ho.ct
+++ b/test/Integration/code/ho.ct
@@ -1,12 +1,12 @@
-# Tests higher order functions
+import "core"
 
+
+# Tests higher order functions
 data(T(x))
 
 tst[$T](d= T(x -> $T), f(y -> $T) -> Boolean) -> Boolean
-
 tst(d= T(x), f(y))= f(y= x)
 
 main{io -> IO} =
   #assert(test= tst(d= T(0), f(y)= y == 0))
   io
-

--- a/test/Integration/code/id.ct
+++ b/test/Integration/code/id.ct
@@ -1,8 +1,9 @@
+import "core"
+
+
 # Tests an identity function.
   It requires using the type of the input argument as the output type of id as well.
   So, it must be read as `id($T) -> $T`, not (id(Any) -> Any).
-
 id(x)= x
 
 main{io -> IO}= io.exit(val= id(x= 0))
-

--- a/test/Integration/code/idVar.ct
+++ b/test/Integration/code/idVar.ct
@@ -1,7 +1,8 @@
+import "core"
+
+
 # Tests id with type variables.
   This is one of the simplest tests with type variables.
-
 id[$T](x -> $T) -> $T= x
 
 main{io -> IO}= io.exit(val= id(x= 0))
-

--- a/test/Integration/code/ifThenElse.ct
+++ b/test/Integration/code/ifThenElse.ct
@@ -1,8 +1,10 @@
-# Tests the "if-then-else" syntax with an absolute value
+import "core"
 
+
+# Tests the "if-then-else" syntax with an absolute value
 abs(x -> Integer)= if(x >= 0)
   Then= x
+
   Else= -1 * x
 
 main{io -> IO}= io.exit(val= abs(0))
-

--- a/test/Integration/code/intlist.ct
+++ b/test/Integration/code/intlist.ct
@@ -1,16 +1,14 @@
-# The intlist tests recursive data structures without type variables
+import "core"
 
+
+# The intlist tests recursive data structures without type variables
 class(IntList, [IntCons(head -> Integer, tail -> IntList), IntNil])
 
 # operator+:(Integer l, ConsList r) = Cons(head=l, tail=r)
-
 :IntList.len -> Integer
-
 :IntNil.len= 0
 
 # TODO: Fix example below which should work without explicit return value
-
 :/IntCons(head, tail).len -> Integer= 1 + tail.len
 
 main{io -> IO}= io.exit(val= IntCons(head= 5, tail= IntCons(head= 3, tail= IntNil)).len - 2)
-

--- a/test/Integration/code/io.ct
+++ b/test/Integration/code/io.ct
@@ -1,1 +1,4 @@
+import "core"
+
+
 main{io -> IO}= io.println(msg= "hello world").exit(val= 0)

--- a/test/Integration/code/list.ct
+++ b/test/Integration/code/list.ct
@@ -1,10 +1,9 @@
+import "core"
+
+
 # The list tests recursive data structures without type variables
-
 # TODO: Use core length rather than llength
-
 Nil.llength= 0
-
 Cons(head, tail).llength= 1 + tail.llength
 
 main{io -> IO}= io.exit(val= [5, 3].llength - 2)
-

--- a/test/Integration/code/match.ct
+++ b/test/Integration/code/match.ct
@@ -1,8 +1,9 @@
-# Tests the match syntax
+import "core"
 
+
+# Tests the match syntax
 main{io -> IO}= io.exit(val= abs(0))
 
 abs(x -> Integer)= match(x)
   x2 | x >= 0= x2
   x2 else = x2 * -1
-

--- a/test/Integration/code/maybeSimple.ct
+++ b/test/Integration/code/maybeSimple.ct
@@ -1,10 +1,10 @@
-# Tests a simple data structure with a true union
+import "core"
 
+
+# Tests a simple data structure with a true union
 class(Maybe[$T], [$T, /Nothing])
 
 defInt(x -> Integer)= x
-
 defInt(x= Nothing)= 0
 
 main{io -> IO}= io.exit(val= defInt(x= 0))
-

--- a/test/Integration/code/maybeVerbose.ct
+++ b/test/Integration/code/maybeVerbose.ct
@@ -1,10 +1,10 @@
-# Tests a simple data structure with a sum type
+import "core"
 
+
+# Tests a simple data structure with a sum type
 class(Maybe[$T], [Just[$T](val -> $T), Nothing])
 
 defInt(x= Just(val -> Integer))= val
-
 defInt(x= Nothing)= 0
 
 main{io -> IO}= io.exit(val= defInt(x= Just(val= 0)))
-

--- a/test/Integration/code/rec.ct
+++ b/test/Integration/code/rec.ct
@@ -1,8 +1,8 @@
+import "core"
+
+
 # Tests recursion
-
 fact(x -> Integer) | x == 1= 1
-
 fact(x -> Integer) else = x * fact(x= x - 1)
 
 main{io -> IO}= io.exit(val= fact(3) - 6)
-

--- a/test/Integration/code/refine.ct
+++ b/test/Integration/code/refine.ct
@@ -1,16 +1,15 @@
+import "core"
+
+
 # Tests refinement types with type properties
-  
   TODO: Convert evenAdd to return (Integer | even($out)), switch to type props, switch to using refinement definition of addition rather than separate evenadd function
-  
   - Convert evenAdd to check | even(a) && even(b)
   - Convert evenAdd to return (Integer | even($out))
   - switch to type props
   - switch to using refinement definition of addition rather than separate evenadd function
-
-even(x: Integer) -> Bool = x % 2 == 0
+even(x -> Integer) -> Bool= x % 2 == 0
 
 # evenAdd(a: Integer_even, b: Integer_even) -> Integer_even = a + b
-
-evenAdd(a: Integer, b: Integer) | even(a) -> Integer = a + b
+evenAdd(a -> Integer, b -> Integer) | even(a) -> Integer= a + b
 
 main{io -> IO}= io.exit(val= evenAdd(a= 2, b= 4) - 6)

--- a/test/Integration/code/show.ct
+++ b/test/Integration/code/show.ct
@@ -1,8 +1,9 @@
-# Tests the toString method, later will be the Show class
+import "core"
 
+
+# Tests the toString method, later will be the Show class
 showInt= 1.toString == "1"
 
 main{io -> IO} =
   #assert(test= showInt)
   io
-

--- a/test/Integration/code/web.ct
+++ b/test/Integration/code/web.ct
@@ -1,7 +1,8 @@
+import "core"
+
+
 # Tests using a custom build type [www].
   It also prints the result of the build in an iframe.
-
 main= www("<html><body>web test</body></html>")
 
 #print(p= main)
-

--- a/test/Integration/disabled/context.ct
+++ b/test/Integration/disabled/context.ct
@@ -1,7 +1,9 @@
+import "core"
+
+
 # Tests using the context
   It requires using the type of the input argument as the output type of id as well.
   So, it must be read as `id($T) -> $T`, not (id(Any) -> Any).
-
 data(Counter(i -> Integer))
 
 inc{c= Counter(i)}= (){Counter(i + 1)}
@@ -12,4 +14,3 @@ main{io -> IO} =
   _<- (){Counter(0)}
   _<- inc{}
   io.exit(val= 0)
-

--- a/test/Integration/disabled/mutRec.ct
+++ b/test/Integration/disabled/mutRec.ct
@@ -1,12 +1,11 @@
+import "core"
+
+
 # Tests two functions that are recursive by mutually calling each other.
-
 even(x -> Integer) | x == 0= 0
-
 even(x -> Integer) else = odd(x= x - 1)
 
 odd(x -> Integer) | x == 0= 1
-
 odd(x -> Integer) else = even(x= x - 1)
 
 main{io -> IO}= io.exit(val= odd(x= 4))
-

--- a/test/Semantics/code/Animals.ct
+++ b/test/Semantics/code/Animals.ct
@@ -1,18 +1,16 @@
 annot(#noCore)
-#noCore
 
+#noCore
 module(Data/Primitive)
   data(Number)
+
   class(Boolean, [True, False])
 
 class(Animal)
-
 class(Fish)
-
 class(Lizard)
 
 every(Fish, isa= [/Animal])
-
 every(Lizard, isa= [/Animal])
 
 class(Mammal, [Cat, Dog], isa= [/Animal])
@@ -20,7 +18,7 @@ class(Mammal, [Cat, Dog], isa= [/Animal])
 :Animal.weight -> Number
 
 :Animal.fluffy -> Boolean
-:Fish.fluffy = False
-:Lizard.fluffy = False
-:Cat.fluffy = True
-:Dog.fluffy = True
+:Fish.fluffy= False
+:Lizard.fluffy= False
+:Cat.fluffy= True
+:Dog.fluffy= True

--- a/test/Semantics/code/containers.ct
+++ b/test/Semantics/code/containers.ct
@@ -1,13 +1,11 @@
 annot(#noCore)
-#noCore
 
+#noCore
 data(Integer)
 
 class(List[$T])
-
 class(ConsList[$T], [Cons[$T -> $T](head -> $T, tail -> ConsList[$T -> $T]), Nil])
 
 every(ConsList, isa= [/List])
 
 :List.length -> Integer
-


### PR DESCRIPTION
## Summary
- Update the Catln formatter to insert blank lines between definitions whose `objExprPath` differs, while keeping definitions of the same path (overloads/clauses) grouped together
- Annotations (`# md` doc comments, `> print`) stay attached to adjacent statements with no extra blank line, so a doc comment continues to sit immediately above the definition it documents
- Hidden statements (`#else`, `#ctx`) don't trigger blank lines
- Reformats all `.ct`/`.ctx` files in the repo with the new rules

## Implementation notes
The new logic lives in `formatStatementTrees`, which inserts a single newline between adjacent statement trees when `needsBlankLine` returns True. Decision rules (in order):

1. Hidden statements never trigger a blank line
2. If `prev` is an annotation, no blank line (annotation belongs with what follows)
3. If `curr` is an annotation, blank line (a new doc-commented group is starting)
4. Otherwise, blank line iff `stmtObjPath prev /= stmtObjPath curr`

One subtlety: the `stringbuilder` package's `IsString Builder` instance appends a trailing `\n` to every string literal. Using `"\n"` in a `do` block therefore produces two newlines, not one. The new code uses `literal "\n"` to insert exactly one newline.

## Test plan
- [x] `stack test --test-arguments="-p FormatTests"` passes (29/29, idempotency check on every `.ct` in the repo)
- [x] `make ctformat` applied to all `.ct`/`.ctx` files in the repo
- [ ] Pre-existing integration test failures from a UTF-8 decode error on `test/Integration/golden/desugar/stack/core/algebra.txt` are unrelated to this change

https://claude.ai/code/session_01Mom4U51GzroJSR3r7nNSTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mom4U51GzroJSR3r7nNSTf)_